### PR TITLE
弃用 ObservableValue 并规范 ViewModel getter

### DIFF
--- a/.agents/skills/view_model/SKILL.md
+++ b/.agents/skills/view_model/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: view_model
-description: Build or refactor Flutter state management with the view_model package, including ViewModel/ViewModelBinding mixins, ViewModelSpec sharing, watch/read semantics, lifecycle, pause-resume, testing, and code generation.
+description: Build or refactor Flutter functional modules and state management with the view_model package, including module-to-module dependency injection, ViewModel/ViewModelBinding mixins, ViewModelSpec sharing, watch/read semantics, lifecycle, pause-resume, testing, and code generation.
 mintlify-proj: flutter-view-model
 ---
 
@@ -34,12 +34,22 @@ Use this skill for requests like:
 - "用 view_model 写/改状态管理"
 - "watch/read 有什么区别"
 - "ViewModelSpec 怎么做共享/单例"
+- "每个功能模块都是 ViewModel / ViewModel 之间如何依赖注入"
 - "StateViewModel / listenStateSelect / ValueWatcher"
 - "生命周期、自动销毁、pause/resume"
 - "`@GenSpec` 或 view_model_generator"
 
 ## Core model (must stay accurate)
 
+- **Every functional module can be a ViewModel.** A ViewModel is not limited to
+  page or UI state: a feature, service, repository, coordinator, or domain
+  capability can all be modeled as `class X with ViewModel`.
+- **ViewModel modules can inject each other.** Resolve module dependencies with
+  non-caching `viewModelBinding.read/watch` getters. This forms a demand-driven
+  module-to-module DI graph managed by binding-based reference counting.
+- **Prefer managed instances over singletons.** Do not make a module static,
+  global, keyed, or `aliveForever` by default. Let the first `read/watch`
+  create it and let `ViewModelBinding` dispose it automatically.
 - Architecture is type-keyed instance registry + binding-based reference counting.
 - Two base mixins:
   - `with ViewModel`: managed instance (lifecycle + notify + DI access).
@@ -47,6 +57,141 @@ Use this skill for requests like:
 - Widget mixins are wrappers over `ViewModelBinding`:
   - `ViewModelStateMixin` (recommended default for widgets).
   - `ViewModelStatelessMixin` (lightweight, but has multi-mount caveat).
+
+## Feature-module architecture
+
+Treat `ViewModel` as the reusable unit of application functionality, rather
+than as a class reserved for a screen. Keep each module independently
+constructible through a `ViewModelSpec`, then compose larger modules by
+injecting the smaller ViewModels they depend on:
+
+```dart
+class CheckoutViewModel with ViewModel {
+  CartViewModel get cart => viewModelBinding.read(cartViewModelSpec);
+  PricingViewModel get pricing =>
+      viewModelBinding.read(pricingViewModelSpec);
+
+  Future<void> submit() async {
+    final cart = this.cart;
+    final pricing = this.pricing;
+    await pricing.validate(cart.items);
+  }
+}
+```
+
+- Prefer a getter over `late final`, a constructor-cached field, or `??=`.
+  A getter re-resolves the dependency through the owner binding currently
+  selected by `refHandler`—the first remaining owner, not necessarily the
+  caller's root. Within one binding, the registry still returns the same
+  managed instance.
+- Use `read` when a module only needs to call another module.
+- Use `watch` when dependency notifications must also update the parent
+  binding. Do not put `listen` in a repeatedly evaluated getter because every
+  evaluation can register another side-effect listener; register it explicitly
+  in the binding owner instead.
+- Keep dependency access inside `viewModelBinding` so each resolved module is
+  owned and released by the root binding that resolved it.
+- A ViewModel's identity is the resolved generic VM type `T` plus its effective
+  `key`; the builder's runtime result type is not part of identity, and `tag`
+  is only a grouping label. When factory `key()` returns `null`, the binding
+  supplies a private default key, so the same `T` is reused within one binding
+  and is isolated across bindings. Add a key to share across bindings,
+  distinguish multiple instances of the same `T` in one binding, or provide
+  stable keyed cached lookup. A key does not keep an instance alive.
+
+### App composed from ViewModel modules (pseudo-code)
+
+An app can be a graph of many small ViewModel modules. Specs below deliberately
+have no `key` and no `aliveForever`; they are managed instances, not
+singletons:
+
+```dart
+final sessionSpec = ViewModelSpec(builder: SessionViewModel.new);
+final catalogSpec = ViewModelSpec(builder: CatalogViewModel.new);
+final cartSpec = ViewModelSpec(builder: CartViewModel.new);
+final paymentSpec = ViewModelSpec(builder: PaymentViewModel.new);
+final checkoutSpec = ViewModelSpec(builder: CheckoutViewModel.new);
+final appSpec = ViewModelSpec(builder: AppViewModel.new);
+
+class SessionViewModel with ViewModel { /* login / token */ }
+
+class CatalogViewModel with ViewModel { /* products / search */ }
+
+class CartViewModel with ViewModel { /* cart state */ }
+
+class PaymentViewModel with ViewModel { /* payment capability */ }
+
+class CheckoutViewModel with ViewModel {
+  SessionViewModel get session => viewModelBinding.read(sessionSpec);
+  CartViewModel get cart => viewModelBinding.read(cartSpec);
+  PaymentViewModel get payment => viewModelBinding.read(paymentSpec);
+
+  Future<void> submit() async {
+    final session = this.session;
+    final cart = this.cart;
+    final payment = this.payment;
+    await payment.pay(user: session.user, items: cart.items);
+  }
+}
+
+class AppViewModel with ViewModel {
+  SessionViewModel get session => viewModelBinding.read(sessionSpec);
+  CatalogViewModel get catalog => viewModelBinding.read(catalogSpec);
+  CartViewModel get cart => viewModelBinding.read(cartSpec);
+  CheckoutViewModel get checkout => viewModelBinding.read(checkoutSpec);
+}
+
+class _AppShellState extends State<AppShell> with ViewModelStateMixin {
+  AppViewModel get app => viewModelBinding.watch(appSpec);
+
+  @override
+  Widget build(BuildContext context) => AppView(viewModel: app);
+}
+```
+
+The getter declarations create nothing by themselves. `AppViewModel` is
+created or reused when `_AppShellState.build` evaluates `app`; each child is
+resolved only when its corresponding getter is evaluated. After every getter
+above has been accessed, the conceptual dependency graph is:
+
+```text
+AppShell ViewModelBinding
+└── AppViewModel
+    ├── SessionViewModel
+    ├── CatalogViewModel
+    ├── CartViewModel
+    └── CheckoutViewModel
+        ├── SessionViewModel (same binding-managed instance)
+        ├── CartViewModel (same binding-managed instance)
+        └── PaymentViewModel
+```
+
+When `AppShell` is disposed, its binding releases every module that it actually
+resolved. Any module with no remaining binding reference is disposed
+automatically. This is binding ownership, not a parent-to-child ownership edge:
+recycling a parent does not automatically recycle its children. Keep composite
+or coordinator ViewModels unkeyed by default. If a leaf service must be shared,
+put the explicit `key` on that leaf and make every root resolve it so every root
+obtains its own binding reference.
+
+### Shared-parent lifecycle boundary
+
+A keyed parent ViewModel can be referenced by multiple root bindings, but its
+nested dependencies are not transitively bound to every root that binds the
+parent. `viewModelBinding` resolves through the first remaining owner binding
+selected by `refHandler`, not necessarily the caller's root. A child resolved
+by the shared parent belongs to that selected root unless the other roots
+resolve the child themselves. When that root is disposed, the child may be
+disposed while the keyed parent remains alive under another root.
+
+Non-caching getters prevent the parent from retaining a disposed child: the
+next access re-resolves through the next owner selected by `refHandler`. They
+do not guarantee child state continuity; the child may be recreated. For
+continuous shared state, prefer an unkeyed parent plus a keyed leaf resolved by
+every root, or use a dedicated application-level binding owner. Use
+`aliveForever` only when retention beyond binding lifetime is intentional;
+explicit `recycle` is then responsible for early cleanup. Never cache a nested
+ViewModel in `late final`, `final`, or `??=` on a cross-binding shared parent.
 
 ## Implementation workflow
 
@@ -58,9 +203,15 @@ Use this skill for requests like:
 2. Define `ViewModelSpec`
 - `ViewModelSpec<T>(builder: ...)` for no args.
 - `ViewModelSpec.arg/arg2/arg3/arg4` for parameterized construction.
-- Use `key` for shared instance identity.
+- Identity is resolved generic VM type `T` + effective `key`; `tag` and the
+  builder's runtime result type do not participate in identity.
+- When factory `key()` returns `null`, repeated access to the same `T` reuses
+  one instance within a binding and remains isolated across bindings.
+- Use `key` for cross-binding sharing, multiple same-`T` instances in one
+  binding, or stable keyed cached lookup. It does not keep an instance alive.
 - Use `tag` for grouped lookup.
-- Use `aliveForever: true` only for real process-lifetime singletons.
+- Use `aliveForever: true` only for intentional long-lived retention. It skips
+  automatic disposal at zero binding references; `recycle` still force-disposes.
 
 3. Integrate with host
 - Widget page: `State<T> with ViewModelStateMixin`.
@@ -82,10 +233,15 @@ Use this skill for requests like:
 - `recycle(vm)`: force unbind all and dispose; next `watch/read` gets fresh instance.
 
 5. Handle dependencies and sharing
+- Model each independent functional capability as a ViewModel when it benefits
+  from managed lifecycle, state notifications, dependency injection, or reuse.
 - In a ViewModel, `viewModelBinding` is available via Zone from parent binding.
 - ViewModel-to-ViewModel calls (`read/watch/listen`) are part of the same binding lifecycle chain.
-- Without `key`: per-binding isolated instance.
-- With same `key`: cross-binding shared instance.
+- Resolve nested ViewModels through non-caching getters; do not retain them in
+  `late final`, `final`, or `??=` fields.
+- With `key() == null`: one instance per resolved generic VM type `T` per binding.
+- With same `T` + same `key`: shared identity across bindings.
+- Multiple instances of the same `T` in one binding need distinct keys.
 - Static lookup (`ViewModel.readCached`, `ViewModel.maybeReadCached`) is lookup-only (no bind, no create).
 
 6. Lifecycle and cleanup
@@ -99,7 +255,12 @@ Use this skill for requests like:
 - Built-in pause providers: route cover, ticker mode, app lifecycle.
 - Use `StateViewModelValueWatcher` for selector-level rebuilds; pair it with
   `read`, not `watch`, to avoid duplicate subscriptions and broad rebuilds.
-- `ObservableValue` + `ObserverBuilder(1/2/3)` for lightweight reactive values; same `shareKey` means shared underlying state.
+- `ObservableValue` and `ObserverBuilder(1/2/3)` are deprecated compatibility
+  APIs scheduled for removal in 2.0.0. Do not introduce new usages.
+- Use Flutter's `ValueNotifier` + `ValueListenableBuilder` for widget-local
+  values, or an explicit `StateViewModel` + `ViewModelSpec` for managed state.
+  Add a `key` when cross-binding sharing, multiple same-type instances in one
+  binding, or stable keyed cached lookup is required.
 
 8. App-level setup
 - Call `ViewModel.initialize(...)` once at app startup (subsequent calls are ignored).
@@ -121,6 +282,10 @@ Use this skill for requests like:
 ## Do/Don't checklist
 
 Do:
+- Default feature-module specs to no `key` and no `aliveForever`, allowing the
+  binding to own creation, reuse, and disposal.
+- Expose ViewModels through typed, non-caching getters that call
+  `viewModelBinding.read/watch`.
 - Keep `watch` for reactive UI, `read` for imperative actions.
 - For field-level updates (`listenStateSelect`, `StateViewModelValueWatcher`,
   selector-based rebuilds), read the ViewModel with `read` and let the
@@ -130,9 +295,14 @@ Do:
 - Use `listenStateSelect` for side effects on selected state fields.
 
 Don't:
+- Introduce a global singleton or service locator for ViewModel modules by
+  default; compose modules through `viewModelBinding` instead.
 - Claim `read` is "non-binding" (it still binds and affects lifecycle).
 - Pair selector-level rebuild tools with `watch`; this usually causes broader
   rebuilds than intended.
+- Cache a ViewModel dependency in `late final`, `final`, or `??=`; the active
+  owner binding can change after recycle or shared-parent transfer.
+- Introduce `ObservableValue` or `ObserverBuilder`; they are deprecated.
 - Use cached APIs expecting auto-create behavior.
 - Overuse `aliveForever` for page-scoped state.
 - Forget `ViewModel.routeObserver` when relying on route pause behavior.
@@ -140,6 +310,9 @@ Don't:
 ## Response pattern for implementation requests
 
 When generating code for users:
+- For app architecture, present features as collaborating ViewModel modules;
+  compose them through `viewModelBinding` and default to managed, non-singleton
+  specs without `key` or `aliveForever`.
 - Prefer complete, runnable snippets with:
   - imports
   - ViewModel class

--- a/.agents/skills/view_model/examples/counter_example.dart
+++ b/.agents/skills/view_model/examples/counter_example.dart
@@ -26,7 +26,7 @@ class CounterWidget extends StatefulWidget {
 class _CounterWidgetState extends State<CounterWidget>
     with ViewModelStateMixin {
   // Bind and watch the ViewModel
-  late final vm = viewModelBinding.watch(counterSpec);
+  CounterViewModel get vm => viewModelBinding.watch(counterSpec);
 
   @override
   Widget build(BuildContext context) {

--- a/.agents/skills/view_model/examples/sharing_example.dart
+++ b/.agents/skills/view_model/examples/sharing_example.dart
@@ -14,10 +14,9 @@ final authSpec = ViewModelSpec<AuthService>(
 );
 
 class ProfileViewModel with ViewModel {
-  // Dependency injection via viewModelBinding
-  // It automatically binds ProfileViewModel's lifecycle to AuthService if needed,
-  // but here authSpec is aliveForever.
-  late final auth = viewModelBinding.read(authSpec);
+  // Re-resolve through refHandler's currently selected owner on every access.
+  // The registry still reuses authSpec's keyed instance.
+  AuthService get auth => viewModelBinding.read(authSpec);
 
   String get status => auth.isLoggedIn ? 'Online' : 'Offline';
 }

--- a/.agents/skills/view_model/references/README_FULL_EN.md
+++ b/.agents/skills/view_model/references/README_FULL_EN.md
@@ -1,10 +1,18 @@
-# view_model
+# view_model — State Management, Dependency Injection, and Module Architecture
 
 [![pub package](https://img.shields.io/pub/v/view_model.svg)](https://pub.dev/packages/view_model)
 
 [简体中文](./README_ZH.md)
 
-A Flutter state management library built on a type-keyed instance registry with automatic reference-counted lifecycle.
+**More than state management: view_model is a Flutter architecture for
+dependency injection, functional-module composition, and automatic lifecycle
+management.**
+
+Model each functional unit—UI state, services, repositories, coordinators, or
+domain capabilities—as a ViewModel. ViewModels inject and compose one another
+through `viewModelBinding`, while the binding system resolves only the nodes
+whose getters are accessed, reuses instances within its scope, and disposes
+them automatically.
 
 ```yaml
 dependencies:
@@ -40,13 +48,13 @@ npx skills add https://github.com/lwj1994/flutter_view_model --skill view_model
 - [Instance Sharing](#instance-sharing)
   - [key-based Sharing](#key-based-sharing)
   - [tag-based Lookup](#tag-based-lookup)
-  - [aliveForever Singletons](#aliveforever-singletons)
+  - [aliveForever Retention](#aliveforever-retention)
   - [Static Global Access](#static-global-access)
 - [ViewModelBinding in Any Class](#viewmodelbinding-in-any-class)
 - [ViewModel-to-ViewModel Dependencies](#viewmodel-to-viewmodel-dependencies)
 - [Fine-Grained Reactivity](#fine-grained-reactivity)
   - [StateViewModelValueWatcher](#stateviewmodelvaluewatcher)
-  - [ObservableValue & ObserverBuilder](#observablevalue--observerbuilder)
+  - [Deprecated: ObservableValue & ObserverBuilder](#deprecated-observablevalue--observerbuilder)
 - [Pause / Resume](#pause--resume)
 - [Lifecycle Details](#lifecycle-details)
   - [Reference Counting (Binding)](#reference-counting-binding)
@@ -168,7 +176,7 @@ class CounterPage extends StatefulWidget {
 }
 
 class _CounterPageState extends State<CounterPage> with ViewModelStateMixin {
-  late final vm = viewModelBinding.watch(counterSpec);
+  CounterViewModel get vm => viewModelBinding.watch(counterSpec);
 
   @override
   Widget build(BuildContext context) {
@@ -277,9 +285,24 @@ final chatSpec = ViewModelSpec.arg2<ChatViewModel, String, int>(
 
 Calling `userSpec('abc')` returns a `ViewModelFactory<UserViewModel>` that you can pass to `watch` / `read`.
 
+An instance's identity is the combination of the resolved generic ViewModel
+type `T` and its effective `key`; the builder's runtime result type is not part
+of identity, and `tag` is only a grouping/lookup label. When factory `key()`
+returns `null`, the current `ViewModelBinding` supplies a private default key,
+so repeated `watch`/`read` calls for the same `T` reuse one instance within
+that binding while different bindings remain isolated. Set a key when you need
+to:
+
+- share an instance across bindings;
+- distinguish multiple instances of the same `T` in one binding; or
+- locate an instance through stable `watchCached`/`readCached(key:)` lookup.
+
+A key does not keep an instance alive; retention is controlled separately by
+`aliveForever`.
+
 Internally, `ViewModelSpec` extends `ViewModelFactory<T>`, which defines:
 - `build()` — creates the instance
-- `key()` — cache key (same key = same instance)
+- `key()` — cache key (same resolved `T` + same key = same identity)
 - `tag()` — logical grouping label
 - `aliveForever()` — whether to skip auto-disposal
 
@@ -293,7 +316,7 @@ The primary way to use ViewModels in widgets. Mix it into `State<T>`:
 
 ```dart
 class _MyPageState extends State<MyPage> with ViewModelStateMixin {
-  late final vm = viewModelBinding.watch(mySpec);
+  MyViewModel get vm => viewModelBinding.watch(mySpec);
 
   @override
   Widget build(BuildContext context) {
@@ -333,7 +356,7 @@ Mix into `StatelessWidget` for lightweight usage. The mixin creates a custom `El
 
 ```dart
 class MyWidget extends StatelessWidget with ViewModelStatelessMixin {
-  late final vm = viewModelBinding.watch(mySpec);
+  MyViewModel get vm => viewModelBinding.watch(mySpec);
   MyWidget({super.key});
 
   @override
@@ -439,7 +462,9 @@ final freshVm = viewModelBinding.watch(spec); // new instance
 
 ### key-based Sharing
 
-When a `ViewModelSpec` has a `key`, any binding that calls `watch`/`read` with the same key gets the **same instance**. Each binding adds its own `bindingId` to the handle — the instance stays alive until all bindings unbind.
+When a `ViewModelSpec<T>` has a `key`, any binding that resolves the same `T`
+with an equal key gets the **same instance**. Each binding adds its own
+`bindingId` to the handle — the instance stays alive until all bindings unbind.
 
 ```dart
 final spec = ViewModelSpec<CounterViewModel>(
@@ -454,7 +479,10 @@ viewModelBinding.watch(spec);
 viewModelBinding.watch(spec);
 ```
 
-Without a `key`, each binding creates a new, independent instance scoped to that binding alone.
+When factory `key()` returns `null`, the binding supplies a private default
+key. This gives one instance per resolved generic ViewModel type `T` within
+that binding, isolated from other bindings. To create multiple instances of
+the same `T` in one binding, give their specs distinct keys.
 
 ### tag-based Lookup
 
@@ -467,9 +495,11 @@ final spec = ViewModelSpec<ItemVM>(
 );
 ```
 
-### aliveForever Singletons
+### aliveForever Retention
 
-Set `aliveForever: true` to prevent auto-disposal. When the handle's `bindingIds` becomes empty, `_recycle()` checks this flag and skips disposal. The instance lives until the process ends:
+Set `aliveForever: true` to skip automatic disposal when the handle's
+`bindingIds` becomes empty. The instance remains cached until it is explicitly
+force-disposed with `recycle` or the process ends:
 
 ```dart
 final authSpec = ViewModelSpec<AuthViewModel>(
@@ -553,24 +583,31 @@ You can override `onUpdate()`, `onPause()`, `onResume()` in your class. You can 
 
 ## ViewModel-to-ViewModel Dependencies
 
-Inside a ViewModel, `viewModelBinding` is available and resolves via a Dart Zone to the parent binding that created it. This means ViewModel-to-ViewModel access goes through the same binding system — sub-ViewModels are bound to the same root binding, and their lifecycles are managed together.
+Inside a ViewModel, `viewModelBinding` resolves through the owner binding
+currently selected by `refHandler`: the first remaining owner, not necessarily
+the caller's root. Expose nested ViewModels through non-caching getters so every
+access is resolved through that selected binding. Within one binding, the
+registry still returns the same managed instance:
 
 ```dart
 class OrderViewModel with ViewModel {
-  late final cart = viewModelBinding.read(cartSpec);
-  late final user = viewModelBinding.read(userSpec);
+  CartViewModel get cart => viewModelBinding.read(cartSpec);
+  UserViewModel get user => viewModelBinding.read(userSpec);
 
   double get total => cart.items.fold(0, (sum, i) => sum + i.price);
 }
 ```
 
-Reactive dependencies with `watch` (when the dependency notifies, the parent binding's `onUpdate` fires):
+Prefer a getter over `late final`, a constructor-cached field, or `??=`. This
+also avoids retaining a disposed dependency after recycle or a root-binding
+handoff.
+
+Reactive dependencies use `watch`; when the dependency notifies, the selected
+root binding's `onUpdate` fires:
 
 ```dart
 class DashboardViewModel with ViewModel {
-  DashboardViewModel() {
-    viewModelBinding.watch(authSpec);
-  }
+  AuthViewModel get auth => viewModelBinding.watch(authSpec);
 }
 ```
 
@@ -586,7 +623,20 @@ class ChatViewModel with ViewModel {
 }
 ```
 
-When the root widget's binding disposes, it unbinds from all handles — including those created transitively by ViewModel-to-ViewModel dependencies. If no other binding holds those handles, they are disposed as well.
+When a root binding is disposed, it releases every dependency that it actually
+resolved. If no other binding holds those handles, they are disposed as well.
+Getter declarations alone create nothing; a dependency is created or reused
+only when its getter is evaluated.
+
+> **Shared-parent boundary:** a keyed parent can be held by multiple root
+> bindings, but a child resolved through that parent is not automatically bound
+> to every one of them. If the root that resolved the child is disposed, the
+> child may be disposed while the parent survives. A non-caching getter avoids
+> retaining that disposed child and re-resolves through the next owner selected
+> by `refHandler`, but the child may be recreated and lose its previous state.
+> Prefer an unkeyed composite parent plus keyed leaf dependencies that every
+> root resolves, or a dedicated application-level binding owner when continuity
+> is required.
 
 ---
 
@@ -600,7 +650,7 @@ Only rebuilds when the selected properties of a `StateViewModel` change:
 class _MyPageState extends State<MyPage> with ViewModelStateMixin {
   // Use read — the ValueWatcher handles its own subscriptions internally.
   // Avoid watch here, or the whole ViewModel will still trigger rebuilds.
-  late final vm = viewModelBinding.read(userSpec);
+  UserViewModel get vm => viewModelBinding.read(userSpec);
 
   @override
   Widget build(BuildContext context) {
@@ -619,42 +669,135 @@ from its previous value (compared using `ViewModelConfig.equals` or `==` by
 default). To keep updates truly fine-grained, read the ViewModel with `read`
 and let the selector mechanism drive rebuilds instead of also using `watch`.
 
-### ObservableValue & ObserverBuilder
+### Deprecated: ObservableValue & ObserverBuilder
 
-A lightweight reactive value that doesn't require defining a ViewModel class. Under the hood, each `ObservableValue` creates a hidden `StateViewModel` instance in the registry, keyed by `shareKey`:
+`ObservableValue` and `ObserverBuilder` / `ObserverBuilder2` /
+`ObserverBuilder3` are deprecated and scheduled for removal in 2.0.0. They are
+convenience wrappers around a hidden `StateViewModel`, rather than a core state
+management capability.
 
-```dart
-// Declare (can be top-level)
-final isDarkMode = ObservableValue<bool>(false, shareKey: 'theme-dark');
-
-// Update from anywhere
-isDarkMode.value = true;
-
-// Observe in UI
-ObserverBuilder<bool>(
-  observable: isDarkMode,
-  builder: (dark) => Icon(dark ? Icons.dark_mode : Icons.light_mode),
-)
-```
-
-Multi-value variants:
+For a widget-local reactive value, use Flutter's `ValueNotifier` and
+`ValueListenableBuilder`, and dispose the notifier with its owner:
 
 ```dart
-ObserverBuilder2<int, String>(
-  observable1: counter,
-  observable2: label,
-  builder: (count, label) => Text('$label: $count'),
-)
+class ThemeToggle extends StatefulWidget {
+  const ThemeToggle({super.key});
 
-ObserverBuilder3<int, String, bool>(
-  observable1: counter,
-  observable2: label,
-  observable3: isActive,
-  builder: (count, label, active) => /* ... */,
-)
+  @override
+  State<ThemeToggle> createState() => _ThemeToggleState();
+}
+
+class _ThemeToggleState extends State<ThemeToggle> {
+  final ValueNotifier<bool> _isDarkMode = ValueNotifier<bool>(false);
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: _isDarkMode,
+      builder: (context, isDarkMode, child) {
+        return IconButton(
+          icon: Icon(isDarkMode ? Icons.dark_mode : Icons.light_mode),
+          onPressed: () => _isDarkMode.value = !isDarkMode,
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _isDarkMode.dispose();
+    super.dispose();
+  }
+}
 ```
 
-If two `ObservableValue` instances share the same `shareKey`, they point to the same underlying StateViewModel — this is how you share reactive values across unrelated parts of the widget tree.
+For state that needs view_model lifecycle management, model it explicitly with
+`StateViewModel` and `ViewModelSpec`. This example uses a keyed non-widget
+binding owner so producers can read and update the state before the observing
+widget mounts or while it is unmounted:
+
+```dart
+class ThemeModeViewModel extends StateViewModel<bool> {
+  ThemeModeViewModel() : super(state: false);
+
+  void setDarkMode(bool value) => setState(value);
+}
+
+final themeModeSpec = ViewModelSpec<ThemeModeViewModel>(
+  builder: ThemeModeViewModel.new,
+  key: 'theme-dark',
+);
+
+class ThemeModeOwner with ViewModelBinding {
+  ThemeModeViewModel get themeMode =>
+      viewModelBinding.read(themeModeSpec);
+
+  void setDarkMode(bool value) => themeMode.setDarkMode(value);
+}
+
+class ThemeModeExample extends StatefulWidget {
+  const ThemeModeExample({super.key});
+
+  @override
+  State<ThemeModeExample> createState() => _ThemeModeExampleState();
+}
+
+class _ThemeModeExampleState extends State<ThemeModeExample> {
+  final ThemeModeOwner _owner = ThemeModeOwner();
+
+  @override
+  void initState() {
+    super.initState();
+    // Creates and updates the instance before the observing child mounts.
+    _owner.setDarkMode(true);
+  }
+
+  @override
+  Widget build(BuildContext context) => const ThemeModeButton();
+
+  @override
+  void dispose() {
+    _owner.dispose();
+    super.dispose();
+  }
+}
+
+class ThemeModeButton extends StatefulWidget {
+  const ThemeModeButton({super.key});
+
+  @override
+  State<ThemeModeButton> createState() => _ThemeModeButtonState();
+}
+
+class _ThemeModeButtonState extends State<ThemeModeButton>
+    with ViewModelStateMixin {
+  ThemeModeViewModel get themeMode =>
+      viewModelBinding.watch(themeModeSpec);
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = themeMode;
+    return IconButton(
+      icon: Icon(viewModel.state ? Icons.dark_mode : Icons.light_mode),
+      onPressed: () => viewModel.setDarkMode(!viewModel.state),
+    );
+  }
+}
+```
+
+`ThemeModeExample` demonstrates the ownership boundary: it updates the state
+before `ThemeModeButton` mounts, retains it while the child is absent, and
+disposes the non-widget owner when the scope ends. An application, service, or
+bootstrap scope follows the same pattern. The key is needed here for
+cross-binding sharing; it is also required when distinguishing multiple
+same-`T` instances inside one binding. It does not replace an owner or keep
+the instance alive by itself. Use `aliveForever` only for intentional
+process-lifetime retention, which then requires explicit recycle or process
+termination for cleanup.
+
+When migrating `ObserverBuilder2` or `ObserverBuilder3`, prefer one state object
+that contains the related values. This keeps ownership and update boundaries
+explicit instead of assembling application state from standalone observables.
 
 ---
 
@@ -738,11 +881,9 @@ Register cleanup callbacks with `addDispose`. They run in order during `onDispos
 
 ```dart
 class StreamViewModel with ViewModel {
-  late final StreamSubscription _sub;
-
   StreamViewModel() {
-    _sub = someStream.listen((_) => notifyListeners());
-    addDispose(() => _sub.cancel());
+    final subscription = someStream.listen((_) => notifyListeners());
+    addDispose(subscription.cancel);
   }
 }
 ```
@@ -944,14 +1085,14 @@ Both are built on a central registry + dependency injection model, but they diff
 | :--- | :--- | :--- |
 | **Class model** | Inheritance/codegen-based (`Notifier`, `AsyncNotifier`, `@riverpod`) | **Mixin-based** (`class X with ViewModel`) |
 | **Strengths** | Strong provider composition and reactive derivation patterns | Low-intrusion style, multi-mixin flexibility, any Dart class can become a ViewModel |
-| **watch/read location** | In `Consumer` widgets, `ref.watch(...)` is commonly used in `build`; it is also used inside provider/notifier `build`. For listeners outside `build` in widgets, `WidgetRef.listenManual(...)` is available | Can be declared as class fields (`late final vm = viewModelBinding.watch(...)`), not forced into `build` |
+| **watch/read location** | In `Consumer` widgets, `ref.watch(...)` is commonly used in `build`; it is also used inside provider/notifier `build`. For listeners outside `build` in widgets, `WidgetRef.listenManual(...)` is available | Can be exposed through a getter (`MyViewModel get vm => viewModelBinding.watch(...)`), not forced into `build` |
 
-**view_model example (field declaration):**
+**view_model example (getter declaration):**
 
 ```dart
 class _MyPageState extends State<MyPage> with ViewModelStateMixin {
-  late final counterVM = viewModelBinding.watch(counterSpec); // initialized once
-  late final userVM = viewModelBinding.watch(userSpec);
+  CounterViewModel get counterVM => viewModelBinding.watch(counterSpec);
+  UserViewModel get userVM => viewModelBinding.watch(userSpec);
 
   @override
   Widget build(BuildContext context) {
@@ -963,7 +1104,7 @@ class _MyPageState extends State<MyPage> with ViewModelStateMixin {
 ### 3. Instance Scope (Most Important Difference)
 
 - **Riverpod**: instances are scoped by `ProviderContainer`. In most apps, a single root `ProviderScope` means one shared provider instance app-wide. Isolation is explicit via nested `ProviderScope`, overrides, or families.
-- **view_model**: default is **per-binding singleton**. Repeated `watch/read` calls inside the same `ViewModelBinding` share one instance; different pages/bindings are isolated by default. Global sharing is explicit via key:
+- **view_model**: the default is one instance per resolved generic ViewModel type `T` per binding. Repeated same-`T` `watch/read` calls inside one `ViewModelBinding` reuse that instance; different pages/bindings are isolated. Use explicit keys for cross-binding sharing or multiple same-`T` instances inside one binding:
 
 ```dart
 final globalAuthSpec = ViewModelSpec<AuthViewModel>(

--- a/.agents/skills/view_model/references/README_FULL_ZH.md
+++ b/.agents/skills/view_model/references/README_FULL_ZH.md
@@ -1,12 +1,15 @@
-# view_model
+# view_model：状态管理、依赖注入与模块架构
 
 [![pub package](https://img.shields.io/pub/v/view_model.svg)](https://pub.dev/packages/view_model)
 
 [English](./README.md)
 
-**一切皆 ViewModel。**
+**不只是状态管理。view_model 同时是一套面向 Flutter 的依赖注入、功能模块组合与自动生命周期管理架构。**
 
-这是一个为 Flutter 量身定制的状态管理框架。它基于“类型键（Type-keyed）实例注册表”构建，并自带“自动引用计数”的生命周期管理系统。无需繁琐的初始化，真正做到**按需创建，自动销毁**。
+每个功能单元——页面状态、服务、仓储、协调器或领域能力——都可以是
+ViewModel。ViewModel 之间通过 `viewModelBinding` 相互依赖注入与组合，
+由 `ViewModelBinding` 在 getter 被实际访问时按需解析对应节点、在作用域内
+复用实例，并自动完成回收；无需依赖全局单例。
 
 ```yaml
 dependencies:
@@ -35,6 +38,7 @@ npx skills add https://github.com/lwj1994/flutter_view_model --skill view_model
 - [🏗️ 在任意非 Widget 类中使用](#️-在任意非-widget-类中使用)
 - [🔄 ViewModel 间的强力联动](#-viewmodel-间的强力联动)
 - [⚡ 细粒度更新（性能优化）](#-细粒度更新性能优化)
+- [⚠️ ObservableValue 迁移](#️-observablevalue-迁移)
 - [💤 智能 暂停 / 恢复 机制](#-智能-暂停--恢复-机制)
 - [♻️ 生命周期细节与资源回收](#-生命周期细节与资源回收)
 - [🛠️ 全局配置与调试](#-全局配置与调试)
@@ -117,7 +121,7 @@ class CounterPage extends StatefulWidget {
 
 class _CounterPageState extends State<CounterPage> with ViewModelStateMixin {
   // watch 会建立连接：ViewModel 变了，当前 Widget 自动刷新
-  late final vm = viewModelBinding.watch(counterSpec);
+  CounterViewModel get vm => viewModelBinding.watch(counterSpec);
 
   @override
   Widget build(BuildContext context) {
@@ -135,6 +139,10 @@ class _CounterPageState extends State<CounterPage> with ViewModelStateMixin {
 
 ### StateViewModel（强状态版）
 如果你追求不可变状态（配合 `Freezed` 简直完美），它是你的不二之选。它能记录 `previousState`，并支持字段级的差异化监听（`listenStateSelect`）。
+
+做字段级更新时，建议用 `read` 读取 ViewModel，再交给
+`listenStateSelect` / `StateViewModelValueWatcher` 驱动更新；不要再对同一
+个 ViewModel 额外使用 `watch`，否则会把整份 ViewModel 的宽范围监听也挂上。
 
 ```dart
 class UserViewModel extends StateViewModel<UserState> {
@@ -156,6 +164,158 @@ StreamViewModel() {
 }
 ```
 
+## 🔄 ViewModel 间的强力联动
+
+ViewModel 内部的依赖统一通过非缓存 getter 获取。getter 每次都会经由
+`refHandler` 当前选中的 owner binding（首个仍存在的 owner，不一定是调用方
+root）解析，但同一 binding 内仍会复用同一个受管实例：
+
+```dart
+class OrderViewModel with ViewModel {
+  CartViewModel get cart => viewModelBinding.read(cartSpec);
+  UserViewModel get user => viewModelBinding.read(userSpec);
+
+  double get total => cart.items.fold(0, (sum, item) => sum + item.price);
+}
+```
+
+优先 getter，不要用 `late final`、构造时缓存或 `??=` 持有嵌套 ViewModel。
+root binding 只负责释放它实际解析过的实例；getter 声明本身不会创建任何
+对象。
+
+> **共享父模块边界：** 一个带 key 的父 ViewModel 可以被多个 root binding
+> 共同持有，但父模块解析出的子依赖不会自动绑定到所有 root。解析子依赖的
+> root 被销毁后，父模块可能仍存活而子模块已经销毁。非缓存 getter 能避免
+> 继续持有已销毁对象，并在下次访问时通过 `refHandler` 新选中的 owner 重新
+> 解析；但子模块可能被重新创建，原状态不保证连续。需要连续共享状态时，
+> 优先使用不带 key 的复合父模块，并让每个 root 都解析带 key 的共享叶子
+> 模块；也可以使用明确的应用级 binding owner。
+
+## ⚠️ ObservableValue 迁移
+
+`ObservableValue`、`ObserverBuilder`、`ObserverBuilder2` 和
+`ObserverBuilder3` 已弃用，计划在 2.0.0 移除。它们只是隐藏
+`StateViewModel` 的便捷封装，并不是核心状态管理能力；1.x 期间仍会保留，
+供现有项目迁移。
+
+Widget 内部的局部响应式值，请改用 Flutter 自带的 `ValueNotifier` 和
+`ValueListenableBuilder`，并由其持有者负责 `dispose`：
+
+```dart
+class ThemeToggle extends StatefulWidget {
+  const ThemeToggle({super.key});
+
+  @override
+  State<ThemeToggle> createState() => _ThemeToggleState();
+}
+
+class _ThemeToggleState extends State<ThemeToggle> {
+  final ValueNotifier<bool> _isDarkMode = ValueNotifier<bool>(false);
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: _isDarkMode,
+      builder: (context, isDarkMode, child) {
+        return IconButton(
+          icon: Icon(isDarkMode ? Icons.dark_mode : Icons.light_mode),
+          onPressed: () => _isDarkMode.value = !isDarkMode,
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _isDarkMode.dispose();
+    super.dispose();
+  }
+}
+```
+
+需要 view_model 自动生命周期管理时，请显式使用 `StateViewModel` 和
+`ViewModelSpec`。下面通过带 key 的非 Widget binding owner 持有状态，因此
+生产者可以在观察 Widget 挂载前或卸载期间继续读取和更新：
+
+```dart
+class ThemeModeViewModel extends StateViewModel<bool> {
+  ThemeModeViewModel() : super(state: false);
+
+  void setDarkMode(bool value) => setState(value);
+}
+
+final themeModeSpec = ViewModelSpec<ThemeModeViewModel>(
+  builder: ThemeModeViewModel.new,
+  key: 'theme-dark',
+);
+
+class ThemeModeOwner with ViewModelBinding {
+  ThemeModeViewModel get themeMode =>
+      viewModelBinding.read(themeModeSpec);
+
+  void setDarkMode(bool value) => themeMode.setDarkMode(value);
+}
+
+class ThemeModeExample extends StatefulWidget {
+  const ThemeModeExample({super.key});
+
+  @override
+  State<ThemeModeExample> createState() => _ThemeModeExampleState();
+}
+
+class _ThemeModeExampleState extends State<ThemeModeExample> {
+  final ThemeModeOwner _owner = ThemeModeOwner();
+
+  @override
+  void initState() {
+    super.initState();
+    // 在观察子 Widget 挂载前创建并更新实例。
+    _owner.setDarkMode(true);
+  }
+
+  @override
+  Widget build(BuildContext context) => const ThemeModeButton();
+
+  @override
+  void dispose() {
+    _owner.dispose();
+    super.dispose();
+  }
+}
+
+class ThemeModeButton extends StatefulWidget {
+  const ThemeModeButton({super.key});
+
+  @override
+  State<ThemeModeButton> createState() => _ThemeModeButtonState();
+}
+
+class _ThemeModeButtonState extends State<ThemeModeButton>
+    with ViewModelStateMixin {
+  ThemeModeViewModel get themeMode =>
+      viewModelBinding.watch(themeModeSpec);
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = themeMode;
+    return IconButton(
+      icon: Icon(viewModel.state ? Icons.dark_mode : Icons.light_mode),
+      onPressed: () => viewModel.setDarkMode(!viewModel.state),
+    );
+  }
+}
+```
+
+`ThemeModeExample` 完整展示了 owner 边界：在 `ThemeModeButton` 挂载前
+更新状态、观察子 Widget 不存在时继续持有状态，并在作用域结束时释放非
+Widget owner。应用、服务或启动作用域也遵循同一模式。这里的 key 用于跨
+binding 共享；同一 binding 内要区分多个同 `T` 实例时也需要不同 key。key
+本身不会保活，也不能替代 owner。只有明确需要进程级常驻并接受显式
+recycle 或进程结束清理时，才使用 `aliveForever`。
+
+迁移 `ObserverBuilder2` 或 `ObserverBuilder3` 时，优先把相关值合并为一个
+明确的状态对象，避免继续用多个独立可观察值拼装业务状态。
+
 ---
 
 ## 🔗 viewModelBinding 核心接口
@@ -168,16 +328,22 @@ StreamViewModel() {
 | **`read(spec)`** | 事件回调、只需调用方法时 | **非响应式**：仅读取，不监听。若 VM 不存在则创建。 |
 | **`watchCached(key/tag)`** | 寻找现有的单例或共享 VM | 如果缓存里没找到，它会抛出异常。 |
 | **`readCached(key/tag)`** | 读取现有缓存但不触发刷新 | 只查找已有实例，不创建；会参与 binding 生命周期，但不响应 `notifyListeners()`。 |
-| **`watchCachesByTag(tag)`** | 按 tag 批量响应式获取 VM | 批量版 `watch`：会 `bind`，也会监听变化。 |
-| **`readCachesByTag(tag)`** | 按 tag 批量读取已有 VM | 批量版 `read`：会 `bind`、参与 dispose 清理，并感知 recreate/dispose，但不响应 `notifyListeners()`。 |
+| **`watchCachesByTag(tag)`** | 按 tag 批量响应式获取 VM | 批量版 `watch`：会 `bind`、响应 `notifyListeners()`，也会感知 recreate/dispose。 |
+| **`readCachesByTag(tag)`** | 按 tag 批量读取已有 VM | 批量版 `read`：会 `bind`、感知 recreate/dispose，并参与 dispose 清理，但不响应 `notifyListeners()`。 |
 | **`listenStateSelect(...)`**| 针对性监听某个字段 | 例如：只有 `user.age` 变了才弹窗，别的字段变了不理。 |
 | **`recycle(vm)`** | 强制销毁重来 | 比如：退出登录时，一键回收所有用户相关的 VM。 |
 
 补充说明：
 
 - `watch*` 和 `read*` 都会建立 binding，都会影响实例生命周期；差别主要在于是否监听 ViewModel 自身的变化。
-- `readCachesByTag(tag)` 不会响应 `notifyListeners()`，但会注册 recreate listener；它不是纯静态查询，binding dispose 时仍会自动 `unbind/removeRef`。
 - 做字段级更新时，优先用 `read` 拿到 ViewModel，再交给 `listenStateSelect` 或 `StateViewModelValueWatcher` 驱动更新；不要再对同一个 ViewModel 额外 `watch`。
+- 实例身份由“解析时使用的泛型 ViewModel 类型 `T` + effective key”共同
+  决定；builder 返回对象的运行时具体类型不参与身份，`tag` 也只用于分组
+  检索。factory 的 `key()` 返回 `null` 时，同一 binding 内同一 `T` 只会
+  复用一个实例，不同 binding 默认隔离。跨 binding 共享、同一 binding 内
+  区分多个同 `T` 实例，
+  或需要稳定的 keyed cached lookup 时，应显式设置 key。key 本身不负责
+  保活；`aliveForever` 只跳过引用归零时的自动回收，显式 `recycle` 仍可销毁。
 
 ---
 
@@ -229,14 +395,14 @@ class CounterViewModel with ViewModel { ... }
 | :--- | :--- | :--- |
 | **类实现方式** | 继承/codegen 为主（`Notifier`/`AsyncNotifier`/`@riverpod`） | **纯 mixin 方式**（`class X with ViewModel`） |
 | **优点** | Provider 组合与响应式派生能力强 | 零侵入、可多 mixin 叠加、任意类可直接成为 ViewModel |
-| **watch/read 位置** | 在 `Consumer` 的 `build` 中常用 `ref.watch(...)`；在 Provider/Notifier 的 `build` 中也可 `ref.watch(...)`；在 Widget 中若需在 `build` 外监听，可用 `WidgetRef.listenManual(...)` | 可直接声明为类字段（如 `late final vm = viewModelBinding.watch(...)`），不强制写在 `build` 内 |
+| **watch/read 位置** | 在 `Consumer` 的 `build` 中常用 `ref.watch(...)`；在 Provider/Notifier 的 `build` 中也可 `ref.watch(...)`；在 Widget 中若需在 `build` 外监听，可用 `WidgetRef.listenManual(...)` | 可通过 getter 暴露（如 `MyViewModel get vm => viewModelBinding.watch(...)`），不强制写在 `build` 内 |
 
-**view_model 示例（字段声明）**：
+**view_model 示例（getter 声明）**：
 
 ```dart
 class _MyPageState extends State<MyPage> with ViewModelStateMixin {
-  late final counterVM = viewModelBinding.watch(counterSpec); // 只初始化一次
-  late final userVM = viewModelBinding.watch(userSpec);
+  CounterViewModel get counterVM => viewModelBinding.watch(counterSpec);
+  UserViewModel get userVM => viewModelBinding.watch(userSpec);
 
   @override
   Widget build(BuildContext context) {
@@ -248,13 +414,13 @@ class _MyPageState extends State<MyPage> with ViewModelStateMixin {
 ### 3. 实例获取与作用域（核心差异）
 
 - **Riverpod**：实例按 `ProviderContainer` 隔离。常见项目只有一个根 `ProviderScope`，因此同一 Provider 在整个 App 内通常共享一份状态；需要隔离时通过局部 `ProviderScope`/override/family 控制。
-- **view_model**：默认 **per-binding 单例**。同一 `ViewModelBinding` 内多次 `watch/read` 共享同实例；不同页面（不同 binding）默认隔离。需要全局共享时显式声明 key：
+- **view_model**：默认是“每个 binding、每个解析类型参数 `T` 一个实例”。同一 `ViewModelBinding` 内对同一 `T` 多次 `watch/read` 会复用实例，不同页面（不同 binding）默认隔离。跨 binding 共享或在同一 binding 内区分多个同 `T` 实例时显式声明 key：
 
 ```dart
 final globalAuthSpec = ViewModelSpec<AuthViewModel>(
   builder: () => AuthViewModel(),
   key: 'global-auth',
-  aliveForever: true, // 可选：常驻
+  aliveForever: true, // 可选：引用归零时仍保留，可显式 recycle
 );
 ```
 

--- a/example/todo_list/lib/todo_view_model.dart
+++ b/example/todo_list/lib/todo_view_model.dart
@@ -38,21 +38,22 @@ class TodoViewModel extends StateViewModel<TodoState> {
     );
   }
 
-  void editTodo(String id, String newTitle, {String? newCategory}) {
+  void editTodo(
+    String id,
+    String newTitle, {
+    required String? newCategory,
+  }) {
     if (newTitle.trim().isEmpty) return;
 
     final updatedItems = state.items.map((item) {
       if (item.id == id) {
-        if (newCategory != null) {
-          final normalized = newCategory.trim();
-          return item.copyWith(
-            title: newTitle.trim(),
-            category: normalized.isEmpty ? null : normalized,
-          );
-        } else {
-          // Don't pass category — copyWith sentinel preserves existing value.
-          return item.copyWith(title: newTitle.trim());
-        }
+        final normalizedCategory = newCategory?.trim();
+        return item.copyWith(
+          title: newTitle.trim(),
+          category: normalizedCategory == null || normalizedCategory.isEmpty
+              ? null
+              : normalizedCategory,
+        );
       }
       return item;
     }).toList();

--- a/packages/view_model/CHANGELOG.md
+++ b/packages/view_model/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+- Deprecate `ObservableValue` and the `ObserverBuilder` family. Use Flutter's
+  `ValueNotifier` / `ValueListenableBuilder` for widget-local values, or
+  `StateViewModel` / `ViewModelSpec` for lifecycle-managed and shared state.
+  The compatibility APIs remain available in 1.x and are scheduled for removal
+  in 2.0.0.
+
 ## 1.0.4
 - Refactor `AutoDisposeInstanceController.getInstancesByTag` to drop the unused `listen` parameter; recreate-listener attachment is now unconditional, matching the documented semantics of `watchCachesByTag` / `readCachesByTag`.
 

--- a/packages/view_model/README.md
+++ b/packages/view_model/README.md
@@ -1,10 +1,18 @@
-# view_model
+# view_model — State Management, Dependency Injection, and Module Architecture
 
 [![pub package](https://img.shields.io/pub/v/view_model.svg)](https://pub.dev/packages/view_model)
 
 [简体中文](./README_ZH.md)
 
-A Flutter state management library built on a type-keyed instance registry with automatic reference-counted lifecycle.
+**More than state management: view_model is a Flutter architecture for
+dependency injection, functional-module composition, and automatic lifecycle
+management.**
+
+Model each functional unit—UI state, services, repositories, coordinators, or
+domain capabilities—as a ViewModel. ViewModels inject and compose one another
+through `viewModelBinding`, while the binding system resolves only the nodes
+whose getters are accessed, reuses instances within its scope, and disposes
+them automatically.
 
 ```yaml
 dependencies:
@@ -40,13 +48,13 @@ npx skills add https://github.com/lwj1994/flutter_view_model --skill view_model
 - [Instance Sharing](#instance-sharing)
   - [key-based Sharing](#key-based-sharing)
   - [tag-based Lookup](#tag-based-lookup)
-  - [aliveForever Singletons](#aliveforever-singletons)
+  - [aliveForever Retention](#aliveforever-retention)
   - [Static Global Access](#static-global-access)
 - [ViewModelBinding in Any Class](#viewmodelbinding-in-any-class)
 - [ViewModel-to-ViewModel Dependencies](#viewmodel-to-viewmodel-dependencies)
 - [Fine-Grained Reactivity](#fine-grained-reactivity)
   - [StateViewModelValueWatcher](#stateviewmodelvaluewatcher)
-  - [ObservableValue & ObserverBuilder](#observablevalue--observerbuilder)
+  - [Deprecated: ObservableValue & ObserverBuilder](#deprecated-observablevalue--observerbuilder)
 - [Pause / Resume](#pause--resume)
 - [Lifecycle Details](#lifecycle-details)
   - [Reference Counting (Binding)](#reference-counting-binding)
@@ -168,7 +176,7 @@ class CounterPage extends StatefulWidget {
 }
 
 class _CounterPageState extends State<CounterPage> with ViewModelStateMixin {
-  late final vm = viewModelBinding.watch(counterSpec);
+  CounterViewModel get vm => viewModelBinding.watch(counterSpec);
 
   @override
   Widget build(BuildContext context) {
@@ -277,9 +285,24 @@ final chatSpec = ViewModelSpec.arg2<ChatViewModel, String, int>(
 
 Calling `userSpec('abc')` returns a `ViewModelFactory<UserViewModel>` that you can pass to `watch` / `read`.
 
+An instance's identity is the combination of the resolved generic ViewModel
+type `T` and its effective `key`; the builder's runtime result type is not part
+of identity, and `tag` is only a grouping/lookup label. When factory `key()`
+returns `null`, the current `ViewModelBinding` supplies a private default key,
+so repeated `watch`/`read` calls for the same `T` reuse one instance within
+that binding while different bindings remain isolated. Set a key when you need
+to:
+
+- share an instance across bindings;
+- distinguish multiple instances of the same `T` in one binding; or
+- locate an instance through stable `watchCached`/`readCached(key:)` lookup.
+
+A key does not keep an instance alive; retention is controlled separately by
+`aliveForever`.
+
 Internally, `ViewModelSpec` extends `ViewModelFactory<T>`, which defines:
 - `build()` — creates the instance
-- `key()` — cache key (same key = same instance)
+- `key()` — cache key (same resolved `T` + same key = same identity)
 - `tag()` — logical grouping label
 - `aliveForever()` — whether to skip auto-disposal
 
@@ -293,7 +316,7 @@ The primary way to use ViewModels in widgets. Mix it into `State<T>`:
 
 ```dart
 class _MyPageState extends State<MyPage> with ViewModelStateMixin {
-  late final vm = viewModelBinding.watch(mySpec);
+  MyViewModel get vm => viewModelBinding.watch(mySpec);
 
   @override
   Widget build(BuildContext context) {
@@ -333,7 +356,7 @@ Mix into `StatelessWidget` for lightweight usage. The mixin creates a custom `El
 
 ```dart
 class MyWidget extends StatelessWidget with ViewModelStatelessMixin {
-  late final vm = viewModelBinding.watch(mySpec);
+  MyViewModel get vm => viewModelBinding.watch(mySpec);
   MyWidget({super.key});
 
   @override
@@ -439,7 +462,9 @@ final freshVm = viewModelBinding.watch(spec); // new instance
 
 ### key-based Sharing
 
-When a `ViewModelSpec` has a `key`, any binding that calls `watch`/`read` with the same key gets the **same instance**. Each binding adds its own `bindingId` to the handle — the instance stays alive until all bindings unbind.
+When a `ViewModelSpec<T>` has a `key`, any binding that resolves the same `T`
+with an equal key gets the **same instance**. Each binding adds its own
+`bindingId` to the handle — the instance stays alive until all bindings unbind.
 
 ```dart
 final spec = ViewModelSpec<CounterViewModel>(
@@ -454,7 +479,10 @@ viewModelBinding.watch(spec);
 viewModelBinding.watch(spec);
 ```
 
-Without a `key`, each binding creates a new, independent instance scoped to that binding alone.
+When factory `key()` returns `null`, the binding supplies a private default
+key. This gives one instance per resolved generic ViewModel type `T` within
+that binding, isolated from other bindings. To create multiple instances of
+the same `T` in one binding, give their specs distinct keys.
 
 ### tag-based Lookup
 
@@ -467,9 +495,11 @@ final spec = ViewModelSpec<ItemVM>(
 );
 ```
 
-### aliveForever Singletons
+### aliveForever Retention
 
-Set `aliveForever: true` to prevent auto-disposal. When the handle's `bindingIds` becomes empty, `_recycle()` checks this flag and skips disposal. The instance lives until the process ends:
+Set `aliveForever: true` to skip automatic disposal when the handle's
+`bindingIds` becomes empty. The instance remains cached until it is explicitly
+force-disposed with `recycle` or the process ends:
 
 ```dart
 final authSpec = ViewModelSpec<AuthViewModel>(
@@ -553,24 +583,31 @@ You can override `onUpdate()`, `onPause()`, `onResume()` in your class. You can 
 
 ## ViewModel-to-ViewModel Dependencies
 
-Inside a ViewModel, `viewModelBinding` is available and resolves via a Dart Zone to the parent binding that created it. This means ViewModel-to-ViewModel access goes through the same binding system — sub-ViewModels are bound to the same root binding, and their lifecycles are managed together.
+Inside a ViewModel, `viewModelBinding` resolves through the owner binding
+currently selected by `refHandler`: the first remaining owner, not necessarily
+the caller's root. Expose nested ViewModels through non-caching getters so every
+access is resolved through that selected binding. Within one binding, the
+registry still returns the same managed instance:
 
 ```dart
 class OrderViewModel with ViewModel {
-  late final cart = viewModelBinding.read(cartSpec);
-  late final user = viewModelBinding.read(userSpec);
+  CartViewModel get cart => viewModelBinding.read(cartSpec);
+  UserViewModel get user => viewModelBinding.read(userSpec);
 
   double get total => cart.items.fold(0, (sum, i) => sum + i.price);
 }
 ```
 
-Reactive dependencies with `watch` (when the dependency notifies, the parent binding's `onUpdate` fires):
+Prefer a getter over `late final`, a constructor-cached field, or `??=`. This
+also avoids retaining a disposed dependency after recycle or a root-binding
+handoff.
+
+Reactive dependencies use `watch`; when the dependency notifies, the selected
+root binding's `onUpdate` fires:
 
 ```dart
 class DashboardViewModel with ViewModel {
-  DashboardViewModel() {
-    viewModelBinding.watch(authSpec);
-  }
+  AuthViewModel get auth => viewModelBinding.watch(authSpec);
 }
 ```
 
@@ -586,7 +623,20 @@ class ChatViewModel with ViewModel {
 }
 ```
 
-When the root widget's binding disposes, it unbinds from all handles — including those created transitively by ViewModel-to-ViewModel dependencies. If no other binding holds those handles, they are disposed as well.
+When a root binding is disposed, it releases every dependency that it actually
+resolved. If no other binding holds those handles, they are disposed as well.
+Getter declarations alone create nothing; a dependency is created or reused
+only when its getter is evaluated.
+
+> **Shared-parent boundary:** a keyed parent can be held by multiple root
+> bindings, but a child resolved through that parent is not automatically bound
+> to every one of them. If the root that resolved the child is disposed, the
+> child may be disposed while the parent survives. A non-caching getter avoids
+> retaining that disposed child and re-resolves through the next owner selected
+> by `refHandler`, but the child may be recreated and lose its previous state.
+> Prefer an unkeyed composite parent plus keyed leaf dependencies that every
+> root resolves, or a dedicated application-level binding owner when continuity
+> is required.
 
 ---
 
@@ -600,7 +650,7 @@ Only rebuilds when the selected properties of a `StateViewModel` change:
 class _MyPageState extends State<MyPage> with ViewModelStateMixin {
   // Use read — the ValueWatcher handles its own subscriptions internally.
   // Avoid watch here, or the whole ViewModel will still trigger rebuilds.
-  late final vm = viewModelBinding.read(userSpec);
+  UserViewModel get vm => viewModelBinding.read(userSpec);
 
   @override
   Widget build(BuildContext context) {
@@ -619,42 +669,135 @@ from its previous value (compared using `ViewModelConfig.equals` or `==` by
 default). To keep updates truly fine-grained, read the ViewModel with `read`
 and let the selector mechanism drive rebuilds instead of also using `watch`.
 
-### ObservableValue & ObserverBuilder
+### Deprecated: ObservableValue & ObserverBuilder
 
-A lightweight reactive value that doesn't require defining a ViewModel class. Under the hood, each `ObservableValue` creates a hidden `StateViewModel` instance in the registry, keyed by `shareKey`:
+`ObservableValue` and `ObserverBuilder` / `ObserverBuilder2` /
+`ObserverBuilder3` are deprecated and scheduled for removal in 2.0.0. They are
+convenience wrappers around a hidden `StateViewModel`, rather than a core state
+management capability.
 
-```dart
-// Declare (can be top-level)
-final isDarkMode = ObservableValue<bool>(false, shareKey: 'theme-dark');
-
-// Update from anywhere
-isDarkMode.value = true;
-
-// Observe in UI
-ObserverBuilder<bool>(
-  observable: isDarkMode,
-  builder: (dark) => Icon(dark ? Icons.dark_mode : Icons.light_mode),
-)
-```
-
-Multi-value variants:
+For a widget-local reactive value, use Flutter's `ValueNotifier` and
+`ValueListenableBuilder`, and dispose the notifier with its owner:
 
 ```dart
-ObserverBuilder2<int, String>(
-  observable1: counter,
-  observable2: label,
-  builder: (count, label) => Text('$label: $count'),
-)
+class ThemeToggle extends StatefulWidget {
+  const ThemeToggle({super.key});
 
-ObserverBuilder3<int, String, bool>(
-  observable1: counter,
-  observable2: label,
-  observable3: isActive,
-  builder: (count, label, active) => /* ... */,
-)
+  @override
+  State<ThemeToggle> createState() => _ThemeToggleState();
+}
+
+class _ThemeToggleState extends State<ThemeToggle> {
+  final ValueNotifier<bool> _isDarkMode = ValueNotifier<bool>(false);
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: _isDarkMode,
+      builder: (context, isDarkMode, child) {
+        return IconButton(
+          icon: Icon(isDarkMode ? Icons.dark_mode : Icons.light_mode),
+          onPressed: () => _isDarkMode.value = !isDarkMode,
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _isDarkMode.dispose();
+    super.dispose();
+  }
+}
 ```
 
-If two `ObservableValue` instances share the same `shareKey`, they point to the same underlying StateViewModel — this is how you share reactive values across unrelated parts of the widget tree.
+For state that needs view_model lifecycle management, model it explicitly with
+`StateViewModel` and `ViewModelSpec`. This example uses a keyed non-widget
+binding owner so producers can read and update the state before the observing
+widget mounts or while it is unmounted:
+
+```dart
+class ThemeModeViewModel extends StateViewModel<bool> {
+  ThemeModeViewModel() : super(state: false);
+
+  void setDarkMode(bool value) => setState(value);
+}
+
+final themeModeSpec = ViewModelSpec<ThemeModeViewModel>(
+  builder: ThemeModeViewModel.new,
+  key: 'theme-dark',
+);
+
+class ThemeModeOwner with ViewModelBinding {
+  ThemeModeViewModel get themeMode =>
+      viewModelBinding.read(themeModeSpec);
+
+  void setDarkMode(bool value) => themeMode.setDarkMode(value);
+}
+
+class ThemeModeExample extends StatefulWidget {
+  const ThemeModeExample({super.key});
+
+  @override
+  State<ThemeModeExample> createState() => _ThemeModeExampleState();
+}
+
+class _ThemeModeExampleState extends State<ThemeModeExample> {
+  final ThemeModeOwner _owner = ThemeModeOwner();
+
+  @override
+  void initState() {
+    super.initState();
+    // Creates and updates the instance before the observing child mounts.
+    _owner.setDarkMode(true);
+  }
+
+  @override
+  Widget build(BuildContext context) => const ThemeModeButton();
+
+  @override
+  void dispose() {
+    _owner.dispose();
+    super.dispose();
+  }
+}
+
+class ThemeModeButton extends StatefulWidget {
+  const ThemeModeButton({super.key});
+
+  @override
+  State<ThemeModeButton> createState() => _ThemeModeButtonState();
+}
+
+class _ThemeModeButtonState extends State<ThemeModeButton>
+    with ViewModelStateMixin {
+  ThemeModeViewModel get themeMode =>
+      viewModelBinding.watch(themeModeSpec);
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = themeMode;
+    return IconButton(
+      icon: Icon(viewModel.state ? Icons.dark_mode : Icons.light_mode),
+      onPressed: () => viewModel.setDarkMode(!viewModel.state),
+    );
+  }
+}
+```
+
+`ThemeModeExample` demonstrates the ownership boundary: it updates the state
+before `ThemeModeButton` mounts, retains it while the child is absent, and
+disposes the non-widget owner when the scope ends. An application, service, or
+bootstrap scope follows the same pattern. The key is needed here for
+cross-binding sharing; it is also required when distinguishing multiple
+same-`T` instances inside one binding. It does not replace an owner or keep
+the instance alive by itself. Use `aliveForever` only for intentional
+process-lifetime retention, which then requires explicit recycle or process
+termination for cleanup.
+
+When migrating `ObserverBuilder2` or `ObserverBuilder3`, prefer one state object
+that contains the related values. This keeps ownership and update boundaries
+explicit instead of assembling application state from standalone observables.
 
 ---
 
@@ -738,11 +881,9 @@ Register cleanup callbacks with `addDispose`. They run in order during `onDispos
 
 ```dart
 class StreamViewModel with ViewModel {
-  late final StreamSubscription _sub;
-
   StreamViewModel() {
-    _sub = someStream.listen((_) => notifyListeners());
-    addDispose(() => _sub.cancel());
+    final subscription = someStream.listen((_) => notifyListeners());
+    addDispose(subscription.cancel);
   }
 }
 ```
@@ -944,14 +1085,14 @@ Both are built on a central registry + dependency injection model, but they diff
 | :--- | :--- | :--- |
 | **Class model** | Inheritance/codegen-based (`Notifier`, `AsyncNotifier`, `@riverpod`) | **Mixin-based** (`class X with ViewModel`) |
 | **Strengths** | Strong provider composition and reactive derivation patterns | Low-intrusion style, multi-mixin flexibility, any Dart class can become a ViewModel |
-| **watch/read location** | In `Consumer` widgets, `ref.watch(...)` is commonly used in `build`; it is also used inside provider/notifier `build`. For listeners outside `build` in widgets, `WidgetRef.listenManual(...)` is available | Can be declared as class fields (`late final vm = viewModelBinding.watch(...)`), not forced into `build` |
+| **watch/read location** | In `Consumer` widgets, `ref.watch(...)` is commonly used in `build`; it is also used inside provider/notifier `build`. For listeners outside `build` in widgets, `WidgetRef.listenManual(...)` is available | Can be exposed through a getter (`MyViewModel get vm => viewModelBinding.watch(...)`), not forced into `build` |
 
-**view_model example (field declaration):**
+**view_model example (getter declaration):**
 
 ```dart
 class _MyPageState extends State<MyPage> with ViewModelStateMixin {
-  late final counterVM = viewModelBinding.watch(counterSpec); // initialized once
-  late final userVM = viewModelBinding.watch(userSpec);
+  CounterViewModel get counterVM => viewModelBinding.watch(counterSpec);
+  UserViewModel get userVM => viewModelBinding.watch(userSpec);
 
   @override
   Widget build(BuildContext context) {
@@ -963,7 +1104,7 @@ class _MyPageState extends State<MyPage> with ViewModelStateMixin {
 ### 3. Instance Scope (Most Important Difference)
 
 - **Riverpod**: instances are scoped by `ProviderContainer`. In most apps, a single root `ProviderScope` means one shared provider instance app-wide. Isolation is explicit via nested `ProviderScope`, overrides, or families.
-- **view_model**: default is **per-binding singleton**. Repeated `watch/read` calls inside the same `ViewModelBinding` share one instance; different pages/bindings are isolated by default. Global sharing is explicit via key:
+- **view_model**: the default is one instance per resolved generic ViewModel type `T` per binding. Repeated same-`T` `watch/read` calls inside one `ViewModelBinding` reuse that instance; different pages/bindings are isolated. Use explicit keys for cross-binding sharing or multiple same-`T` instances inside one binding:
 
 ```dart
 final globalAuthSpec = ViewModelSpec<AuthViewModel>(

--- a/packages/view_model/README_ZH.md
+++ b/packages/view_model/README_ZH.md
@@ -1,12 +1,15 @@
-# view_model
+# view_model：状态管理、依赖注入与模块架构
 
 [![pub package](https://img.shields.io/pub/v/view_model.svg)](https://pub.dev/packages/view_model)
 
 [English](./README.md)
 
-**一切皆 ViewModel。**
+**不只是状态管理。view_model 同时是一套面向 Flutter 的依赖注入、功能模块组合与自动生命周期管理架构。**
 
-这是一个为 Flutter 量身定制的状态管理框架。它基于“类型键（Type-keyed）实例注册表”构建，并自带“自动引用计数”的生命周期管理系统。无需繁琐的初始化，真正做到**按需创建，自动销毁**。
+每个功能单元——页面状态、服务、仓储、协调器或领域能力——都可以是
+ViewModel。ViewModel 之间通过 `viewModelBinding` 相互依赖注入与组合，
+由 `ViewModelBinding` 在 getter 被实际访问时按需解析对应节点、在作用域内
+复用实例，并自动完成回收；无需依赖全局单例。
 
 ```yaml
 dependencies:
@@ -35,6 +38,7 @@ npx skills add https://github.com/lwj1994/flutter_view_model --skill view_model
 - [🏗️ 在任意非 Widget 类中使用](#️-在任意非-widget-类中使用)
 - [🔄 ViewModel 间的强力联动](#-viewmodel-间的强力联动)
 - [⚡ 细粒度更新（性能优化）](#-细粒度更新性能优化)
+- [⚠️ ObservableValue 迁移](#️-observablevalue-迁移)
 - [💤 智能 暂停 / 恢复 机制](#-智能-暂停--恢复-机制)
 - [♻️ 生命周期细节与资源回收](#-生命周期细节与资源回收)
 - [🛠️ 全局配置与调试](#-全局配置与调试)
@@ -117,7 +121,7 @@ class CounterPage extends StatefulWidget {
 
 class _CounterPageState extends State<CounterPage> with ViewModelStateMixin {
   // watch 会建立连接：ViewModel 变了，当前 Widget 自动刷新
-  late final vm = viewModelBinding.watch(counterSpec);
+  CounterViewModel get vm => viewModelBinding.watch(counterSpec);
 
   @override
   Widget build(BuildContext context) {
@@ -160,6 +164,158 @@ StreamViewModel() {
 }
 ```
 
+## 🔄 ViewModel 间的强力联动
+
+ViewModel 内部的依赖统一通过非缓存 getter 获取。getter 每次都会经由
+`refHandler` 当前选中的 owner binding（首个仍存在的 owner，不一定是调用方
+root）解析，但同一 binding 内仍会复用同一个受管实例：
+
+```dart
+class OrderViewModel with ViewModel {
+  CartViewModel get cart => viewModelBinding.read(cartSpec);
+  UserViewModel get user => viewModelBinding.read(userSpec);
+
+  double get total => cart.items.fold(0, (sum, item) => sum + item.price);
+}
+```
+
+优先 getter，不要用 `late final`、构造时缓存或 `??=` 持有嵌套 ViewModel。
+root binding 只负责释放它实际解析过的实例；getter 声明本身不会创建任何
+对象。
+
+> **共享父模块边界：** 一个带 key 的父 ViewModel 可以被多个 root binding
+> 共同持有，但父模块解析出的子依赖不会自动绑定到所有 root。解析子依赖的
+> root 被销毁后，父模块可能仍存活而子模块已经销毁。非缓存 getter 能避免
+> 继续持有已销毁对象，并在下次访问时通过 `refHandler` 新选中的 owner 重新
+> 解析；但子模块可能被重新创建，原状态不保证连续。需要连续共享状态时，
+> 优先使用不带 key 的复合父模块，并让每个 root 都解析带 key 的共享叶子
+> 模块；也可以使用明确的应用级 binding owner。
+
+## ⚠️ ObservableValue 迁移
+
+`ObservableValue`、`ObserverBuilder`、`ObserverBuilder2` 和
+`ObserverBuilder3` 已弃用，计划在 2.0.0 移除。它们只是隐藏
+`StateViewModel` 的便捷封装，并不是核心状态管理能力；1.x 期间仍会保留，
+供现有项目迁移。
+
+Widget 内部的局部响应式值，请改用 Flutter 自带的 `ValueNotifier` 和
+`ValueListenableBuilder`，并由其持有者负责 `dispose`：
+
+```dart
+class ThemeToggle extends StatefulWidget {
+  const ThemeToggle({super.key});
+
+  @override
+  State<ThemeToggle> createState() => _ThemeToggleState();
+}
+
+class _ThemeToggleState extends State<ThemeToggle> {
+  final ValueNotifier<bool> _isDarkMode = ValueNotifier<bool>(false);
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: _isDarkMode,
+      builder: (context, isDarkMode, child) {
+        return IconButton(
+          icon: Icon(isDarkMode ? Icons.dark_mode : Icons.light_mode),
+          onPressed: () => _isDarkMode.value = !isDarkMode,
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _isDarkMode.dispose();
+    super.dispose();
+  }
+}
+```
+
+需要 view_model 自动生命周期管理时，请显式使用 `StateViewModel` 和
+`ViewModelSpec`。下面通过带 key 的非 Widget binding owner 持有状态，因此
+生产者可以在观察 Widget 挂载前或卸载期间继续读取和更新：
+
+```dart
+class ThemeModeViewModel extends StateViewModel<bool> {
+  ThemeModeViewModel() : super(state: false);
+
+  void setDarkMode(bool value) => setState(value);
+}
+
+final themeModeSpec = ViewModelSpec<ThemeModeViewModel>(
+  builder: ThemeModeViewModel.new,
+  key: 'theme-dark',
+);
+
+class ThemeModeOwner with ViewModelBinding {
+  ThemeModeViewModel get themeMode =>
+      viewModelBinding.read(themeModeSpec);
+
+  void setDarkMode(bool value) => themeMode.setDarkMode(value);
+}
+
+class ThemeModeExample extends StatefulWidget {
+  const ThemeModeExample({super.key});
+
+  @override
+  State<ThemeModeExample> createState() => _ThemeModeExampleState();
+}
+
+class _ThemeModeExampleState extends State<ThemeModeExample> {
+  final ThemeModeOwner _owner = ThemeModeOwner();
+
+  @override
+  void initState() {
+    super.initState();
+    // 在观察子 Widget 挂载前创建并更新实例。
+    _owner.setDarkMode(true);
+  }
+
+  @override
+  Widget build(BuildContext context) => const ThemeModeButton();
+
+  @override
+  void dispose() {
+    _owner.dispose();
+    super.dispose();
+  }
+}
+
+class ThemeModeButton extends StatefulWidget {
+  const ThemeModeButton({super.key});
+
+  @override
+  State<ThemeModeButton> createState() => _ThemeModeButtonState();
+}
+
+class _ThemeModeButtonState extends State<ThemeModeButton>
+    with ViewModelStateMixin {
+  ThemeModeViewModel get themeMode =>
+      viewModelBinding.watch(themeModeSpec);
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = themeMode;
+    return IconButton(
+      icon: Icon(viewModel.state ? Icons.dark_mode : Icons.light_mode),
+      onPressed: () => viewModel.setDarkMode(!viewModel.state),
+    );
+  }
+}
+```
+
+`ThemeModeExample` 完整展示了 owner 边界：在 `ThemeModeButton` 挂载前
+更新状态、观察子 Widget 不存在时继续持有状态，并在作用域结束时释放非
+Widget owner。应用、服务或启动作用域也遵循同一模式。这里的 key 用于跨
+binding 共享；同一 binding 内要区分多个同 `T` 实例时也需要不同 key。key
+本身不会保活，也不能替代 owner。只有明确需要进程级常驻并接受显式
+recycle 或进程结束清理时，才使用 `aliveForever`。
+
+迁移 `ObserverBuilder2` 或 `ObserverBuilder3` 时，优先把相关值合并为一个
+明确的状态对象，避免继续用多个独立可观察值拼装业务状态。
+
 ---
 
 ## 🔗 viewModelBinding 核心接口
@@ -181,6 +337,13 @@ StreamViewModel() {
 
 - `watch*` 和 `read*` 都会建立 binding，都会影响实例生命周期；差别主要在于是否监听 ViewModel 自身的变化。
 - 做字段级更新时，优先用 `read` 拿到 ViewModel，再交给 `listenStateSelect` 或 `StateViewModelValueWatcher` 驱动更新；不要再对同一个 ViewModel 额外 `watch`。
+- 实例身份由“解析时使用的泛型 ViewModel 类型 `T` + effective key”共同
+  决定；builder 返回对象的运行时具体类型不参与身份，`tag` 也只用于分组
+  检索。factory 的 `key()` 返回 `null` 时，同一 binding 内同一 `T` 只会
+  复用一个实例，不同 binding 默认隔离。跨 binding 共享、同一 binding 内
+  区分多个同 `T` 实例，
+  或需要稳定的 keyed cached lookup 时，应显式设置 key。key 本身不负责
+  保活；`aliveForever` 只跳过引用归零时的自动回收，显式 `recycle` 仍可销毁。
 
 ---
 
@@ -232,14 +395,14 @@ class CounterViewModel with ViewModel { ... }
 | :--- | :--- | :--- |
 | **类实现方式** | 继承/codegen 为主（`Notifier`/`AsyncNotifier`/`@riverpod`） | **纯 mixin 方式**（`class X with ViewModel`） |
 | **优点** | Provider 组合与响应式派生能力强 | 零侵入、可多 mixin 叠加、任意类可直接成为 ViewModel |
-| **watch/read 位置** | 在 `Consumer` 的 `build` 中常用 `ref.watch(...)`；在 Provider/Notifier 的 `build` 中也可 `ref.watch(...)`；在 Widget 中若需在 `build` 外监听，可用 `WidgetRef.listenManual(...)` | 可直接声明为类字段（如 `late final vm = viewModelBinding.watch(...)`），不强制写在 `build` 内 |
+| **watch/read 位置** | 在 `Consumer` 的 `build` 中常用 `ref.watch(...)`；在 Provider/Notifier 的 `build` 中也可 `ref.watch(...)`；在 Widget 中若需在 `build` 外监听，可用 `WidgetRef.listenManual(...)` | 可通过 getter 暴露（如 `MyViewModel get vm => viewModelBinding.watch(...)`），不强制写在 `build` 内 |
 
-**view_model 示例（字段声明）**：
+**view_model 示例（getter 声明）**：
 
 ```dart
 class _MyPageState extends State<MyPage> with ViewModelStateMixin {
-  late final counterVM = viewModelBinding.watch(counterSpec); // 只初始化一次
-  late final userVM = viewModelBinding.watch(userSpec);
+  CounterViewModel get counterVM => viewModelBinding.watch(counterSpec);
+  UserViewModel get userVM => viewModelBinding.watch(userSpec);
 
   @override
   Widget build(BuildContext context) {
@@ -251,13 +414,13 @@ class _MyPageState extends State<MyPage> with ViewModelStateMixin {
 ### 3. 实例获取与作用域（核心差异）
 
 - **Riverpod**：实例按 `ProviderContainer` 隔离。常见项目只有一个根 `ProviderScope`，因此同一 Provider 在整个 App 内通常共享一份状态；需要隔离时通过局部 `ProviderScope`/override/family 控制。
-- **view_model**：默认 **per-binding 单例**。同一 `ViewModelBinding` 内多次 `watch/read` 共享同实例；不同页面（不同 binding）默认隔离。需要全局共享时显式声明 key：
+- **view_model**：默认是“每个 binding、每个解析类型参数 `T` 一个实例”。同一 `ViewModelBinding` 内对同一 `T` 多次 `watch/read` 会复用实例，不同页面（不同 binding）默认隔离。跨 binding 共享或在同一 binding 内区分多个同 `T` 实例时显式声明 key：
 
 ```dart
 final globalAuthSpec = ViewModelSpec<AuthViewModel>(
   builder: () => AuthViewModel(),
   key: 'global-auth',
-  aliveForever: true, // 可选：常驻
+  aliveForever: true, // 可选：引用归零时仍保留，可显式 recycle
 );
 ```
 

--- a/packages/view_model/lib/src/get_instance/auto_dispose.dart
+++ b/packages/view_model/lib/src/get_instance/auto_dispose.dart
@@ -177,8 +177,8 @@ class AutoDisposeInstanceController {
         try {
           action(notifier.instance as ViewModel);
         } catch (e, stack) {
-          reportViewModelError(e, stack, ErrorType.lifecycle,
-              'performForAllInstances error');
+          reportViewModelError(
+              e, stack, ErrorType.lifecycle, 'performForAllInstances error');
         }
       }
     }

--- a/packages/view_model/lib/src/get_instance/store.dart
+++ b/packages/view_model/lib/src/get_instance/store.dart
@@ -619,8 +619,7 @@ class InstanceArg {
           aliveForever == other.aliveForever);
 
   @override
-  int get hashCode =>
-      Object.hash(key, tag, bindingId, aliveForever);
+  int get hashCode => Object.hash(key, tag, bindingId, aliveForever);
 
   @override
   String toString() {

--- a/packages/view_model/lib/src/view_model/spec.dart
+++ b/packages/view_model/lib/src/view_model/spec.dart
@@ -1,9 +1,10 @@
 import 'package:view_model/src/view_model/view_model.dart';
 
 /// A simple, argument-less specification for creating a ViewModel.
-/// Provides builder and optional cache identifiers (`key` and `tag`).
-/// Use [key] to reuse the same instance for
-/// identical `key`+`tag`.
+/// Provides a builder, an optional instance `key`, and an optional grouping
+/// `tag`.
+/// Equal non-null [key] values reuse one instance for the same resolved generic
+/// ViewModel type `T`; [tag] is only a grouping and lookup label.
 class ViewModelSpec<T extends ViewModel> extends ViewModelFactory<T> {
   final T Function() builder;
   late final Object? _key;
@@ -16,7 +17,8 @@ class ViewModelSpec<T extends ViewModel> extends ViewModelFactory<T> {
     Object? key,
     Object? tag,
 
-    /// Whether the instance should live forever (never be disposed).
+    /// Whether to skip automatic disposal when no bindings remain.
+    /// Explicit `recycle` still force-disposes the instance.
     bool aliveForever = false,
   }) : _aliveForever = aliveForever {
     _key = key;
@@ -156,7 +158,8 @@ class ViewModelSpecWithArg<VM extends ViewModel, A> {
   /// Computes a cache tag from argument (optional).
   final Object? Function(A argument)? tag;
 
-  /// Whether the instance should live forever (never be disposed).
+  /// Whether to skip automatic disposal when no bindings remain.
+  /// Explicit `recycle` still force-disposes the instance.
   final bool Function(A argument)? aliveForever;
 
   /// Proxy for test-time override.

--- a/packages/view_model/lib/src/view_model/util.dart
+++ b/packages/view_model/lib/src/view_model/util.dart
@@ -7,8 +7,7 @@ class StackPathLocator {
   // Cache path information to avoid repeated retrieval
   String? _cachedObjectPath;
 
-  bool get ready =>
-      _cachedObjectPath != null && _cachedObjectPath!.isNotEmpty;
+  bool get ready => _cachedObjectPath != null && _cachedObjectPath!.isNotEmpty;
 
   /// Gets the file path and line number where this mixin is being used.
   ///

--- a/packages/view_model/lib/src/view_model/value_observer.dart
+++ b/packages/view_model/lib/src/view_model/value_observer.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:flutter/widgets.dart';
 import 'package:view_model/src/get_instance/manager.dart';
 import 'package:view_model/src/get_instance/store.dart';
@@ -10,6 +12,17 @@ import 'package:view_model/src/view_model/widget_mixin/stateful_extension.dart';
 /// trigger a rebuild in any listening [ObserverBuilder].
 ///
 /// The data can be shared and identified by [shareKey].
+///
+/// Deprecated. For widget-local reactive state, use Flutter's
+/// `ValueNotifier<T>` with `ValueListenableBuilder<T>`. For state managed by
+/// this package, use `StateViewModel<T>` with `ViewModelSpec`.
+///
+/// This compatibility API is scheduled for removal in 2.0.0.
+@Deprecated(
+  'Use ValueNotifier with ValueListenableBuilder for widget-local state, '
+  'or StateViewModel with ViewModelSpec for managed state. '
+  'Scheduled for removal in 2.0.0.',
+)
 class ObservableValue<T> {
   /// A key to identify and share this value across different
   /// [ObserverBuilder]s. If not provided, a unique key is
@@ -91,6 +104,14 @@ class _ObserveDataViewModel<T> extends StateViewModel<T> {
 
 /// A widget that listens to an [ObservableValue] and rebuilds whenever the
 /// value changes.
+///
+/// Deprecated. Use Flutter's `ValueListenableBuilder<T>` for widget-local
+/// state, or resolve a `StateViewModel<T>` from a `ViewModelSpec` for managed
+/// state.
+@Deprecated(
+  'Use ValueListenableBuilder for widget-local state, or StateViewModel '
+  'with ViewModelSpec for managed state. Scheduled for removal in 2.0.0.',
+)
 class ObserverBuilder<T> extends StatefulWidget {
   final ObservableValue<T> observable;
 
@@ -137,6 +158,13 @@ class _ObserverBuilderState<T> extends State<ObserverBuilder<T>>
 
 /// A widget that listens to two [ObservableValue]s and rebuilds whenever either
 /// value changes.
+///
+/// Deprecated. Use Flutter's `ValueListenableBuilder` for widget-local state,
+/// or one `StateViewModel` containing both values for managed state.
+@Deprecated(
+  'Use ValueListenableBuilder for widget-local state, or one StateViewModel '
+  'containing both values. Scheduled for removal in 2.0.0.',
+)
 class ObserverBuilder2<T1, T2> extends StatefulWidget {
   final ObservableValue<T1> observable1;
   final ObservableValue<T2> observable2;
@@ -193,6 +221,13 @@ class _ObserverBuilder2State<T1, T2> extends State<ObserverBuilder2<T1, T2>>
 
 /// A widget that listens to three [ObservableValue]s and rebuilds whenever any
 /// value changes.
+///
+/// Deprecated. Use Flutter's `ValueListenableBuilder` for widget-local state,
+/// or one `StateViewModel` containing all values for managed state.
+@Deprecated(
+  'Use ValueListenableBuilder for widget-local state, or one StateViewModel '
+  'containing all values. Scheduled for removal in 2.0.0.',
+)
 class ObserverBuilder3<T1, T2, T3> extends StatefulWidget {
   final ObservableValue<T1> observable1;
   final ObservableValue<T2> observable2;

--- a/packages/view_model/lib/src/view_model/view_model.dart
+++ b/packages/view_model/lib/src/view_model/view_model.dart
@@ -843,10 +843,13 @@ class AutoDisposeController {
 abstract mixin class ViewModelFactory<T> {
   static const _defaultShareId = Object();
 
-  /// Returns a unique key for sharing ViewModel instances.
+  /// Returns an explicit key for identifying ViewModel instances.
   ///
-  /// ViewModels with the same key will be shared across different widgets.
-  /// If this returns `null`, a new instance will be created each time.
+  /// Resolutions using the same generic ViewModel type `T` and equal non-null
+  /// keys share one instance across bindings. If this returns `null`, the
+  /// resolving binding supplies a private default key: repeated resolutions of
+  /// the same `T` reuse one instance in that binding, while different bindings
+  /// remain isolated.
   ///
   /// By default, this returns a shared key when deprecated singleton switches
   /// are enabled, otherwise `null`.
@@ -896,7 +899,9 @@ abstract mixin class ViewModelFactory<T> {
       'singleton() will be removed in a future major release.')
   bool singleton() => false;
 
-  /// Returns `true` if the instance should live forever (never be disposed).
+  /// Returns `true` to skip automatic disposal when no bindings remain.
+  ///
+  /// The instance can still be force-disposed with `recycle`.
   bool aliveForever() => false;
 }
 

--- a/packages/view_model/lib/src/view_model/view_model_binding.dart
+++ b/packages/view_model/lib/src/view_model/view_model_binding.dart
@@ -512,8 +512,7 @@ mixin class ViewModelBinding implements ViewModelBindingInterface {
       getName();
     }
     if (isDisposed) {
-      throw ViewModelError(
-          "Cannot get $VM: "
+      throw ViewModelError("Cannot get $VM: "
           "ViewModelBinding(${getName()}) is already disposed.");
     }
     if (VM == ViewModel || VM == dynamic) {

--- a/packages/view_model/lib/src/view_model/view_model_binding.dart
+++ b/packages/view_model/lib/src/view_model/view_model_binding.dart
@@ -168,11 +168,8 @@ abstract interface class ViewModelBindingHost {
 ///
 /// ```dart
 /// class DownloadService with ViewModelBinding {
-///   late final DownloadViewModel _downloadVM;
-///
-///   DownloadService() {
-///     _downloadVM = viewModelBinding.watch(DownloadViewModelSpec());
-///   }
+///   DownloadViewModel get _downloadVM =>
+///       viewModelBinding.watch(DownloadViewModelSpec());
 ///
 ///   @override
 ///   void onUpdate() {
@@ -381,13 +378,8 @@ mixin class ViewModelBinding implements ViewModelBindingInterface {
   /// Example:
   /// ```dart
   /// class _MyWidgetState extends State<MyWidget> with ViewModelStateMixin {
-  ///   late final MyViewModel _viewModel;
-  ///
-  ///   @override
-  ///   void initState() {
-  ///     super.initState();
-  ///     _viewModel = viewModelBinding.watch(MyViewModelSpec());
-  ///   }
+  ///   MyViewModel get _viewModel =>
+  ///       viewModelBinding.watch(MyViewModelSpec());
   ///
   ///   @override
   ///   Widget build(BuildContext context) {

--- a/packages/view_model/lib/src/view_model/widget_mixin/stateful_extension.dart
+++ b/packages/view_model/lib/src/view_model/widget_mixin/stateful_extension.dart
@@ -23,15 +23,8 @@ import 'package:view_model/src/view_model/widget_mixin/view_model_binding.dart';
 /// }
 ///
 /// class _MyPageState extends State<MyPage> with ViewModelStateMixin<MyPage> {
-///   late final MyViewModel viewModel;
-///
-///   @override
-///   void initState() {
-///     super.initState();
-///     viewModel = viewModelBinding.watch(
-///       MyViewModelSpec(),
-///     );
-///   }
+///   MyViewModel get viewModel =>
+///       viewModelBinding.watch(MyViewModelSpec());
 ///
 ///   @override
 ///   Widget build(BuildContext context) {

--- a/packages/view_model/test/auto_dispose_test.dart
+++ b/packages/view_model/test/auto_dispose_test.dart
@@ -299,6 +299,45 @@ void main() {
       expect(count, 1);
     });
 
+    test('performForAllInstances reports action errors', () {
+      final previousConfig = ViewModel.config;
+      final actionError = StateError('perform action failed');
+      Object? reportedError;
+      StackTrace? reportedStack;
+      ErrorType? reportedType;
+
+      ViewModel.reset();
+      ViewModel.initialize(
+        config: ViewModelConfig(
+          onError: (error, stack, type) {
+            reportedError = error;
+            reportedStack = stack;
+            reportedType = type;
+          },
+        ),
+      );
+      addTearDown(() {
+        controller.dispose();
+        mockRef.dispose();
+        ViewModel.reset();
+        ViewModel.initialize(config: previousConfig);
+      });
+
+      final factory = InstanceFactory<TestStatelessViewModel>(
+        builder: () => TestStatelessViewModel(),
+        arg: const InstanceArg(key: 'perform_error_test'),
+      );
+      controller.getInstance<TestStatelessViewModel>(factory: factory);
+
+      expect(
+        () => controller.performForAllInstances((_) => throw actionError),
+        returnsNormally,
+      );
+      expect(reportedError, same(actionError));
+      expect(reportedStack, isNotNull);
+      expect(reportedType, ErrorType.lifecycle);
+    });
+
     test('unbindInstance', () {
       final factory = InstanceFactory<TestStatelessViewModel>(
         builder: () => TestStatelessViewModel(),

--- a/packages/view_model/test/dependency_resolver_transfer_test.dart
+++ b/packages/view_model/test/dependency_resolver_transfer_test.dart
@@ -7,23 +7,13 @@ import 'package:view_model/view_model.dart';
 class MyViewModel with ViewModel {
   final String name;
 
-  MyViewModel(this.name) {
-    childViewModel1 = viewModelBinding
-        .read<ChildViewModel1>(ViewModelSpec(builder: () => ChildViewModel1()));
-  }
+  MyViewModel(this.name);
 
-  late ChildViewModel2 childViewModel2;
-  late ChildViewModel1 childViewModel1;
-
-  void doSome() {
-    childViewModel2 = viewModelBinding
-        .read<ChildViewModel2>(ViewModelSpec(builder: () => ChildViewModel2()));
-  }
+  ChildViewModel get childViewModel => viewModelBinding
+      .read<ChildViewModel>(ViewModelSpec(builder: ChildViewModel.new));
 }
 
-class ChildViewModel1 with ViewModel {}
-
-class ChildViewModel2 with ViewModel {}
+class ChildViewModel with ViewModel {}
 
 // A stateful widget that uses the ViewModel.
 class MyWidget extends StatefulWidget {
@@ -36,24 +26,16 @@ class MyWidget extends StatefulWidget {
 }
 
 class MyWidgetState extends State<MyWidget> with ViewModelStateMixin<MyWidget> {
-  late MyViewModel vm;
+  MyViewModel get vm => viewModelBinding.watch<MyViewModel>(
+        ViewModelSpec(key: 'share', builder: () => MyViewModel(widget.name)),
+      );
 
-  @override
-  void initState() {
-    super.initState();
-    // Use a key to ensure the same ViewModel instance is shared.
-    vm = viewModelBinding.watch<MyViewModel>(
-      ViewModelSpec(key: "share", builder: () => MyViewModel(widget.name)),
-    );
-  }
-
-  void doSome() {
-    vm.doSome();
-  }
+  ViewModelBinding get testBinding => viewModelBinding;
 
   @override
   Widget build(BuildContext context) {
-    return Text(vm.name);
+    final viewModel = vm;
+    return Text(viewModel.name);
   }
 }
 
@@ -79,6 +61,7 @@ void main() {
     final stateA = tester.state<MyWidgetState>(find.byKey(keyA));
     var stateB = tester.state<MyWidgetState>(find.byKey(keyB));
     final vm = stateA.vm;
+    final initialChild = vm.childViewModel;
 
     // Check that stateA and stateB share the same vm instance
     expect(identical(stateA.vm, stateB.vm), isTrue);
@@ -89,10 +72,11 @@ void main() {
     // Initially, the ViewModel's dependency handler should have resolvers
     // from both states.
     expect(dependencyHandler.ownerResolvers.length, 2);
-    expect(dependencyHandler.ownerResolvers.contains(stateA.viewModelBinding),
-        isTrue);
-    expect(dependencyHandler.ownerResolvers.contains(stateB.viewModelBinding),
-        isTrue);
+    expect(
+        dependencyHandler.ownerResolvers.contains(stateA.testBinding), isTrue);
+    expect(
+        dependencyHandler.ownerResolvers.contains(stateB.testBinding), isTrue);
+    expect(initialChild.refHandler.dependencyBindings, [stateA.testBinding]);
 
     // Dispose StateA by removing its widget.
     await tester.pumpWidget(
@@ -110,24 +94,21 @@ void main() {
     // After StateA is disposed, its resolver should be removed.
     expect(dependencyHandler.ownerResolvers.length, 1);
     // The remaining resolver should be from StateB.
-    expect(dependencyHandler.ownerResolvers.first, stateB.viewModelBinding);
-    expect(dependencyHandler.ownerResolvers.contains(stateA.viewModelBinding),
-        isFalse);
-
-    expect(() => stateB.vm.childViewModel2, throwsA(isA<Error>()));
-
-    stateB.vm.doSome();
-
-    expect(stateB.vm.childViewModel2.refHandler.dependencyBindings.length == 1,
-        true);
+    expect(dependencyHandler.ownerResolvers.first, stateB.testBinding);
     expect(
-        stateB.vm.childViewModel2.refHandler.dependencyBindings
-            .contains(stateB.viewModelBinding),
-        isTrue);
+        dependencyHandler.ownerResolvers.contains(stateA.testBinding), isFalse);
 
-    expect(stateB.vm.isDisposed, false);
-    expect(stateB.vm.childViewModel2.isDisposed, false);
-    expect(stateB.vm.childViewModel1.isDisposed, true);
+    // The child belonged to StateA and is disposed with that root. The getter
+    // must resolve a fresh child through the remaining StateB binding instead
+    // of retaining the disposed instance.
+    expect(initialChild.isDisposed, true);
+    final transferredChild = stateB.vm.childViewModel;
+    expect(identical(transferredChild, initialChild), false);
+    expect(identical(stateB.vm.childViewModel, transferredChild), true);
+    expect(
+        transferredChild.refHandler.dependencyBindings, [stateB.testBinding]);
+    expect(vm.isDisposed, false);
+    expect(transferredChild.isDisposed, false);
     await tester.pumpWidget(
       const MaterialApp(
         home: Column(
@@ -136,9 +117,8 @@ void main() {
       ),
     );
 
-    expect(stateB.vm.isDisposed, true);
-    expect(stateB.vm.childViewModel2.isDisposed, true);
-    expect(stateB.vm.childViewModel1.isDisposed, true);
+    expect(vm.isDisposed, true);
+    expect(transferredChild.isDisposed, true);
   });
 }
 

--- a/packages/view_model/test/value_observer_test.dart
+++ b/packages/view_model/test/value_observer_test.dart
@@ -1,6 +1,8 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:view_model/src/view_model/value_observer.dart';
+import 'package:view_model/view_model.dart';
 
 void main() {
   group('ObservableValue', () {

--- a/packages/view_model/test/view_model_test.dart
+++ b/packages/view_model/test/view_model_test.dart
@@ -295,8 +295,12 @@ void main() {
 
     test('StackPathLocator works', () {
       final locator = StackPathLocator();
+      expect(locator.ready, isFalse);
+
       final path = locator.getCurrentObjectPath();
       expect(path, isNotNull);
+      expect(locator.ready, path.isNotEmpty);
+
       final path2 = locator.getCurrentObjectPath();
       expect(path, path2); // Should be cached
     });


### PR DESCRIPTION
## 变更内容

- 将 `ObservableValue`、`ObserverBuilder`、`ObserverBuilder2` 和 `ObserverBuilder3` 标记为弃用，计划在 2.0.0 移除。
- 提供 `ValueNotifier` 与显式 `StateViewModel + ViewModelSpec` 的完整迁移示例。
- 统一使用 typed getter 通过 `viewModelBinding.read/watch` 获取 ViewModel，避免缓存已销毁实例。
- 补充功能模块组合、共享父 ViewModel 生命周期边界，以及 `T + effective key`、`tag`、`aliveForever` 的准确语义。
- 同步中英文 README、skill reference、公共 API 注释与回归测试。

## 原因

`ObservableValue` 只是隐藏 `StateViewModel` 的扩展属性封装，并非必要的核心能力。与此同时，使用 `late final` 缓存嵌套 ViewModel 时，共享父实例在 root binding 转移后可能继续持有已经销毁的子实例。改用非缓存 getter 可以通过 `refHandler` 当前选中的 owner binding 重新解析依赖。

## 兼容性与影响

- 1.x 继续保留旧 API，现有调用不会立即破坏。
- 新代码不再推荐引入 `ObservableValue` 或缓存 ViewModel 引用。
- getter 能避免 stale disposed reference，但共享父模块切换 owner 后，未共享的子状态仍可能重新创建；文档已明确该边界。

## 验证

- `ff test`：298 项全部通过。
- 针对变更文件执行 `fd analyze`：0 issue。
- 三人并行 review 后复核：无剩余 finding。
- README 与 skill 内嵌中英文 reference 字节级一致。
- `git diff --check` 通过。