### PR TITLE
发布 1.0.5 并补充 README 状态表

### DIFF
--- a/.agents/skills/view_model/references/README_FULL_EN.md
+++ b/.agents/skills/view_model/references/README_FULL_EN.md
@@ -1,6 +1,8 @@
 # view_model — State Management, Dependency Injection, and Module Architecture
 
-[![pub package](https://img.shields.io/pub/v/view_model.svg)](https://pub.dev/packages/view_model)
+| `view_model` | `view_model_annotation` | `view_model_generator` | Coverage |
+| :---: | :---: | :---: | :---: |
+| [![view_model version](https://img.shields.io/pub/v/view_model.svg)](https://pub.dev/packages/view_model) | [![view_model_annotation version](https://img.shields.io/pub/v/view_model_annotation.svg)](https://pub.dev/packages/view_model_annotation) | [![view_model_generator version](https://img.shields.io/pub/v/view_model_generator.svg)](https://pub.dev/packages/view_model_generator) | [![codecov](https://codecov.io/gh/lwj1994/flutter_view_model/branch/main/graph/badge.svg)](https://app.codecov.io/gh/lwj1994/flutter_view_model) |
 
 [简体中文](./README_ZH.md)
 

--- a/.agents/skills/view_model/references/README_FULL_ZH.md
+++ b/.agents/skills/view_model/references/README_FULL_ZH.md
@@ -1,6 +1,8 @@
 # view_model：状态管理、依赖注入与模块架构
 
-[![pub package](https://img.shields.io/pub/v/view_model.svg)](https://pub.dev/packages/view_model)
+| `view_model` | `view_model_annotation` | `view_model_generator` | 覆盖率 |
+| :---: | :---: | :---: | :---: |
+| [![view_model 版本](https://img.shields.io/pub/v/view_model.svg)](https://pub.dev/packages/view_model) | [![view_model_annotation 版本](https://img.shields.io/pub/v/view_model_annotation.svg)](https://pub.dev/packages/view_model_annotation) | [![view_model_generator 版本](https://img.shields.io/pub/v/view_model_generator.svg)](https://pub.dev/packages/view_model_generator) | [![codecov](https://codecov.io/gh/lwj1994/flutter_view_model/branch/main/graph/badge.svg)](https://app.codecov.io/gh/lwj1994/flutter_view_model) |
 
 [English](./README.md)
 

--- a/packages/view_model/CHANGELOG.md
+++ b/packages/view_model/CHANGELOG.md
@@ -1,9 +1,12 @@
-## Unreleased
+## 1.0.5
 - Deprecate `ObservableValue` and the `ObserverBuilder` family. Use Flutter's
   `ValueNotifier` / `ValueListenableBuilder` for widget-local values, or
   `StateViewModel` / `ViewModelSpec` for lifecycle-managed and shared state.
   The compatibility APIs remain available in 1.x and are scheduled for removal
   in 2.0.0.
+- Document getter-based ViewModel dependencies and shared-parent lifecycle
+  boundaries.
+- Show all package versions and Codecov coverage in the README status table.
 
 ## 1.0.4
 - Refactor `AutoDisposeInstanceController.getInstancesByTag` to drop the unused `listen` parameter; recreate-listener attachment is now unconditional, matching the documented semantics of `watchCachesByTag` / `readCachesByTag`.

--- a/packages/view_model/README.md
+++ b/packages/view_model/README.md
@@ -1,6 +1,8 @@
 # view_model — State Management, Dependency Injection, and Module Architecture
 
-[![pub package](https://img.shields.io/pub/v/view_model.svg)](https://pub.dev/packages/view_model)
+| `view_model` | `view_model_annotation` | `view_model_generator` | Coverage |
+| :---: | :---: | :---: | :---: |
+| [![view_model version](https://img.shields.io/pub/v/view_model.svg)](https://pub.dev/packages/view_model) | [![view_model_annotation version](https://img.shields.io/pub/v/view_model_annotation.svg)](https://pub.dev/packages/view_model_annotation) | [![view_model_generator version](https://img.shields.io/pub/v/view_model_generator.svg)](https://pub.dev/packages/view_model_generator) | [![codecov](https://codecov.io/gh/lwj1994/flutter_view_model/branch/main/graph/badge.svg)](https://app.codecov.io/gh/lwj1994/flutter_view_model) |
 
 [简体中文](./README_ZH.md)
 

--- a/packages/view_model/README_ZH.md
+++ b/packages/view_model/README_ZH.md
@@ -1,6 +1,8 @@
 # view_model：状态管理、依赖注入与模块架构
 
-[![pub package](https://img.shields.io/pub/v/view_model.svg)](https://pub.dev/packages/view_model)
+| `view_model` | `view_model_annotation` | `view_model_generator` | 覆盖率 |
+| :---: | :---: | :---: | :---: |
+| [![view_model 版本](https://img.shields.io/pub/v/view_model.svg)](https://pub.dev/packages/view_model) | [![view_model_annotation 版本](https://img.shields.io/pub/v/view_model_annotation.svg)](https://pub.dev/packages/view_model_annotation) | [![view_model_generator 版本](https://img.shields.io/pub/v/view_model_generator.svg)](https://pub.dev/packages/view_model_generator) | [![codecov](https://codecov.io/gh/lwj1994/flutter_view_model/branch/main/graph/badge.svg)](https://app.codecov.io/gh/lwj1994/flutter_view_model) |
 
 [English](./README.md)
 

--- a/packages/view_model/pubspec.lock
+++ b/packages/view_model/pubspec.lock
@@ -428,10 +428,10 @@ packages:
     dependency: "direct main"
     description:
       name: view_model_annotation
-      sha256: "17ec976e3c43dd65880723ac3bf2d1fd1c229a3afa2cff490f81b6d6a6b1ce66"
+      sha256: "4eb7282b81c0c0fea33a7de7764ebcb65d1829d63a65433ff301f17308acff25"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   vm_service:
     dependency: transitive
     description:

--- a/packages/view_model/pubspec.yaml
+++ b/packages/view_model/pubspec.yaml
@@ -2,7 +2,7 @@ name: view_model
 description: Everything is ViewModel. Enjoy automatic lifecycle
   management, prevent memory leaks, and share state effortlessly.
   Simple, lightweight, and powerful.
-version: 1.0.4
+version: 1.0.5
 homepage: https://github.com/lwj1994/flutter_view_model
 repository: https://github.com/lwj1994/flutter_view_model
 issue_tracker: https://github.com/lwj1994/flutter_view_model/issues
@@ -30,7 +30,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta:
-  view_model_annotation: 1.0.4
+  view_model_annotation: 1.0.5
   stack_trace:
 dev_dependencies:
   flutter_test:

--- a/packages/view_model_annotation/CHANGELOG.md
+++ b/packages/view_model_annotation/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.5
+- Version bump for consistency with `view_model` 1.0.5 release.
+
 ## 1.0.4
 - Version bump for consistency with `view_model` 1.0.4 release.
 

--- a/packages/view_model_annotation/pubspec.yaml
+++ b/packages/view_model_annotation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: view_model_annotation
 description: Annotation package for view_model code generation.
-version: 1.0.4
+version: 1.0.5
 homepage: https://github.com/lwj1994/flutter_view_model/tree/main/packages/view_model_annotation
 repository: https://github.com/lwj1994/flutter_view_model/tree/main/packages/view_model_annotation
 issue_tracker: https://github.com/lwj1994/flutter_view_model/issues

--- a/packages/view_model_generator/CHANGELOG.md
+++ b/packages/view_model_generator/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.5
+- Version bump for consistency with `view_model` 1.0.5 release.
+
 ## 1.0.4
 - Version bump for consistency with `view_model` 1.0.4 release.
 

--- a/packages/view_model_generator/example/pubspec.lock
+++ b/packages/view_model_generator/example/pubspec.lock
@@ -401,21 +401,21 @@ packages:
       path: "../../view_model"
       relative: true
     source: path
-    version: "1.0.2"
+    version: "1.0.5"
   view_model_annotation:
     dependency: "direct overridden"
     description:
       path: "../../view_model_annotation"
       relative: true
     source: path
-    version: "1.0.2"
+    version: "1.0.5"
   view_model_generator:
     dependency: "direct dev"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.2"
+    version: "1.0.5"
   watcher:
     dependency: transitive
     description:

--- a/packages/view_model_generator/pubspec.lock
+++ b/packages/view_model_generator/pubspec.lock
@@ -477,10 +477,10 @@ packages:
     dependency: "direct main"
     description:
       name: view_model_annotation
-      sha256: "17ec976e3c43dd65880723ac3bf2d1fd1c229a3afa2cff490f81b6d6a6b1ce66"
+      sha256: "4eb7282b81c0c0fea33a7de7764ebcb65d1829d63a65433ff301f17308acff25"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   vm_service:
     dependency: transitive
     description:

--- a/packages/view_model_generator/pubspec.yaml
+++ b/packages/view_model_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: view_model_generator
 description: Automatically generate ViewModelSpec code from @GenSpec annotations. Reduces boilerplate for the view_model package.
-version: 1.0.4
+version: 1.0.5
 homepage: https://github.com/lwj1994/flutter_view_model/tree/main/packages/view_model_generator
 repository: https://github.com/lwj1994/flutter_view_model/tree/main/packages/view_model_generator
 issue_tracker: https://github.com/lwj1994/flutter_view_model/issues
@@ -13,7 +13,7 @@ dependencies:
   analyzer: ^8.1.1
   source_gen: ^4.0.0
   build: ^4.0.0
-  view_model_annotation: 1.0.4
+  view_model_annotation: 1.0.5
 
 dev_dependencies:
   build_runner: ^2.7.1


### PR DESCRIPTION
## 变更内容

- 将 `view_model_annotation`、`view_model_generator` 和 `view_model` 统一升级到 `1.0.5`。
- 同步 generator、主包及示例锁文件中的版本和精确依赖。
- 在中英文 README 顶部增加状态表，同时展示三个包的 Pub 版本与 Codecov 覆盖率徽章。
- 将三个包的 CHANGELOG 整理为正式 `1.0.5` 发布记录，并同步 skill reference。

## 影响

三个公开包已按 annotation → generator → view_model 的顺序发布，仓库版本元数据与 pub.dev 上的 `1.0.5` 保持一致。

## 验证

- `view_model_annotation`: `fd analyze` 通过。
- `view_model_generator`: `fd test`，39 项全部通过。
- `view_model`: `ff test`，299 项全部通过。
- pub.dev 官方 API 已确认三个 `1.0.5` 版本可用，generator 和主包均精确依赖 annotation `1.0.5`。
- `git diff --check` 通过。

## 发布

- 提交：`4aeda41 publish version:1.0.5`
- 标签：`v1.0.5`